### PR TITLE
bcs-cluster-resources 添加 tracing

### DIFF
--- a/bcs-services/cluster-resources/cmd/init.go
+++ b/bcs-services/cluster-resources/cmd/init.go
@@ -156,6 +156,10 @@ func (crSvc *clusterResourcesService) initMicro() error {
 			wrapper.NewResponseFormatWrapper(),
 		),
 		server.WrapHandler(
+			//	链路追踪
+			wrapper.NewTracingWrapper(),
+		),
+		server.WrapHandler(
 			// 记录 API 访问流水日志
 			wrapper.NewLogWrapper(),
 		),

--- a/bcs-services/cluster-resources/etc/conf.yaml
+++ b/bcs-services/cluster-resources/etc/conf.yaml
@@ -114,3 +114,8 @@ crGlobal:
   sharedCluster:
     enabledCObjKinds: []
     enabledCRDs: []
+
+# TRACING 相关配置
+tracing:
+  tracingEnabled: false
+  exporterURL: "http://localhost:14268/api/traces"

--- a/bcs-services/cluster-resources/go.mod
+++ b/bcs-services/cluster-resources/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20200122045848-3419fae592fc
 	go-micro.dev/v4 v4.8.1
+	go.opentelemetry.io/otel/sdk v1.3.0
 	go.uber.org/zap v1.19.1
 	google.golang.org/genproto v0.0.0-20211020151524-b7c3a969101a
 	google.golang.org/grpc v1.42.0
@@ -73,6 +74,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/logr v1.2.1 // indirect
+	github.com/go-logr/stdr v1.2.0 // indirect
 	github.com/go-playground/locales v0.13.0 // indirect
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
@@ -102,6 +104,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/openzipkin/zipkin-go v0.3.0 // indirect
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/parnurzeal/gorequest v0.2.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -122,6 +125,10 @@ require (
 	go.etcd.io/etcd/api/v3 v3.5.2 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.2 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.2 // indirect
+	go.opentelemetry.io/otel v1.3.0 // indirect
+	go.opentelemetry.io/otel/exporters/jaeger v1.3.0 // indirect
+	go.opentelemetry.io/otel/exporters/zipkin v1.3.0 // indirect
+	go.opentelemetry.io/otel/trace v1.3.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect

--- a/bcs-services/cluster-resources/pkg/config/config.go
+++ b/bcs-services/cluster-resources/pkg/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/TencentBlueKing/iam-go-sdk/metric"
 	jwtGo "github.com/dgrijalva/jwt-go"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
 	"gopkg.in/yaml.v3"
 
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/envs"
@@ -96,6 +97,16 @@ type ClusterResourcesConf struct {
 	Log     LogConf     `yaml:"log"`
 	Redis   RedisConf   `yaml:"redis"`
 	Global  GlobalConf  `yaml:"crGlobal"`
+	Tracing TracingConf `yaml:"tracing"`
+}
+
+// TracingConf 链路追踪配置
+type TracingConf struct {
+	TracingEnabled bool `yaml:"tracingEnabled" usage:"tracing enabled"`
+
+	ExporterURL string `yaml:"exporterURL" usage:"url of exporter"`
+
+	ResourceAttrs []attribute.KeyValue `yaml:"resourceAttrs" usage:"attributes of traced service"`
 }
 
 func (c *ClusterResourcesConf) initServerAddress() error {
@@ -271,7 +282,7 @@ type BCSAPIGatewayConf struct {
 // IAMConf 权限中心相关配置
 type IAMConf struct {
 	Host       string     `yaml:"host" usage:"权限中心 V3 Host"`
-	SystemID   string     `yaml:"systemID" usage:"接入系统的 ID"`                                  // nolint:tagliatelle
+	SystemID   string     `yaml:"systemID" usage:"接入系统的 ID"`                                        // nolint:tagliatelle
 	UseBKAPIGW bool       `yaml:"useBKApiGW" usage:"为真则使用蓝鲸 apigw，否则使用 iamHost + bkPaaSHost"` // nolint:tagliatelle
 	Metric     bool       `yaml:"metric" usage:"支持 prometheus metrics"`
 	Debug      bool       `yaml:"debug" usage:"启用 iam 调试模式"`

--- a/bcs-services/cluster-resources/pkg/tracing/jaeger/init.go
+++ b/bcs-services/cluster-resources/pkg/tracing/jaeger/init.go
@@ -1,0 +1,47 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package jaeger
+
+import (
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/otel/trace"
+	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/config"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+const (
+	TracingType = "jaeger"
+	ServiceName = "bcs-cluster-resources"
+)
+
+func InitTracingInstance(op *config.TracingConf) (*sdktrace.TracerProvider, error) {
+
+	opts := []trace.Option{}
+	if op.TracingEnabled != false {
+		opts = append(opts, trace.TracerSwitch("on"))
+	}
+
+	if TracingType != "" {
+		opts = append(opts, trace.TracerType(TracingType))
+	}
+
+	if op.ExporterURL != "" {
+		opts = append(opts, trace.ExporterURL(op.ExporterURL))
+	}
+	tracer, err := trace.InitTracerProvider(ServiceName, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return tracer, nil
+}

--- a/bcs-services/cluster-resources/pkg/wrapper/jaeger.go
+++ b/bcs-services/cluster-resources/pkg/wrapper/jaeger.go
@@ -1,0 +1,96 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wrapper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"go-micro.dev/v4/server"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/ctxkey"
+)
+
+func NewTracingWrapper() server.HandlerWrapper {
+	return func(fn server.HandlerFunc) server.HandlerFunc {
+		return func(ctx context.Context, req server.Request, rsp interface{}) (err error) {
+			// 开始时间
+			startTime := time.Now().UnixNano() / 1000000
+
+			// 把request-id格式转成trace-id格式
+			requestID := ctx.Value(ctxkey.RequestIDKey).(string)
+			if requestID != "" {
+				requestID = strings.Replace(requestID, "-", "", -1)
+				tid, _ := trace.TraceIDFromHex(requestID)
+				sid, _ := trace.SpanIDFromHex(requestID)
+				sc := trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID:    tid,
+					SpanID:     sid,
+					TraceFlags: trace.FlagsSampled,
+					Remote:     true,
+				})
+				ctx = trace.ContextWithSpanContext(ctx, sc)
+			}
+
+			name := fmt.Sprintf("%s.%s", req.Service(), req.Endpoint())
+
+			tracer := otel.Tracer(req.Endpoint())
+			commonAttrs := []attribute.KeyValue{
+				attribute.String("component", "gRPC"),
+				attribute.String("method", req.Method()),
+				attribute.String("url", req.Endpoint()),
+			}
+			ctx, span := tracer.Start(ctx, name, trace.WithSpanKind(trace.SpanKindServer), trace.WithAttributes(commonAttrs...))
+			defer span.End()
+
+			reqData, _ := json.Marshal(req.Body())
+
+			err = fn(ctx, req, rsp)
+
+			rspData, _ := json.Marshal(rsp)
+			// 结束时间
+			endTime := time.Now().UnixNano() / 1000000
+			costTime := fmt.Sprintf("%vms", endTime-startTime)
+
+			reqBody := string(reqData)
+			if len(reqBody) > 1024 {
+				reqBody = fmt.Sprintf("%s...(Total %s)", reqBody[:1024], humanize.Bytes(uint64(len(reqBody))))
+			}
+
+			respBody := string(rspData)
+			if len(respBody) > 1024 {
+				respBody = fmt.Sprintf("%s...(Total %s)", respBody[:1024], humanize.Bytes(uint64(len(respBody))))
+			}
+
+			// 设置额外标签
+			span.SetAttributes(attribute.Key("req").String(reqBody))
+			span.SetAttributes(attribute.Key("cost_time").String(costTime))
+			span.SetAttributes(attribute.Key("rsp").String(respBody))
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+			}
+
+			return err
+		}
+	}
+}


### PR DESCRIPTION
- 输出添加 tracing 后的API
- 支持jaeger
- 新增 gomicro-v4 / gin tracing 中间件等
- 相关issue: https://github.com/Tencent/bk-bcs/issues/1941