### PR TITLE
helm部署bcs-bscp

### DIFF
--- a/install/helm/bcs-bscp/.helmignore
+++ b/install/helm/bcs-bscp/.helmignore
@@ -21,4 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
-charts/
+# charts/

--- a/install/helm/bcs-bscp/Chart.yaml
+++ b/install/helm/bcs-bscp/Chart.yaml
@@ -7,13 +7,13 @@ appVersion: v1.29.0-alpha.1
 dependencies:
   - condition: etcd.enabled
     name: etcd
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    version: 6.2.11
+    repository: "https://charts.bitnami.com/bitnami"
+    version: 8.7.5
   - name: mariadb
-    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
-    version: 9.4.4
+    repository: "https://charts.bitnami.com/bitnami"
+    version: 11.4.7
     condition: mariadb.enabled
   - name: redis
-    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
-    version: 14.8.11
+    repository: "https://charts.bitnami.com/bitnami"
+    version: 17.7.5
     condition: redis.enabled

--- a/install/helm/bcs-bscp/README.md
+++ b/install/helm/bcs-bscp/README.md
@@ -1,0 +1,141 @@
+# bcs-bscp 本地开发10分钟启动教程(helm) / 文档
+
+使用helm chart部署bcs-bscp应用
+
+#### 部署环境
+
+```
+操作系统环境：CentOS Linux 7 (Core)
+go               1.17
+Docker           20.10.17
+k8s(minikube)    1.23.5
+git              2.38.1      
+helm             3.9.4
+node             16.19.1
+npm              8.19.3
+```
+
+
+
+#### 构建**bcs-bscp**镜像
+
+- **拉取[bk-bcs](https://github.com/Tencent/bk-bcs)项目，拉取完成后找到bcs-bscp项目目录**
+
+  ```
+  git clone https://github.com/Tencent/bk-bcs.git
+  cd bk-bcs/bcs-services/bcs-bscp/
+  ```
+
+- **构建bcs-bscp项目镜像**
+
+  注意：编译前端和UI模块 要求 1.14 版本的 NodeJS（node版本不要太高，经验证1.16也可以）
+
+  要求 1.17 版本的 golang
+
+  编译 pb
+
+  ```bash
+  # 下载正确的 protoc 二进制版本到 .bin 目录
+  make init
+  
+  # 把 .bin/protoc 加到路径中
+  export PATH=`pwd`/.bin:$PATH
+  
+  # 创建 bscp.io 软连接, 已经 gitignore 了这个文件，不会提交到 git 库
+  cd .. && ln -sf bcs-bscp bscp.io && cd bscp.io
+  
+  # 前面的步骤一次性， OK后编译
+  make pb
+  ```
+
+  编译二进制
+
+  ```bash
+  make build_bscp
+  ```
+
+  编译前端和UI模块
+
+  ```bash
+  make build_frontend
+  make build_ui
+  ```
+
+  
+
+  **生成镜像**
+
+  ```
+  make docker
+  ```
+
+#### helm chart部署bcs-bscp项目
+
+- **返回到bk-bcs项目根目录，找到部署bcs-cluster-resources项目的chart包**
+
+  ```
+  cd install/helm/bcs-bscp
+  ```
+
+- **bcs-bcs-bscp chart配置参数都在Value.yaml中，一般只需要修改bcs-bscp配置参数即可运行**
+
+  *cluster-resources配置参数*
+
+  | **Name**            | Description                                                  | Value    |
+  | ------------------- | ------------------------------------------------------------ | -------- |
+  | image.repository    | 镜像名称                                                     | bcs-bscp |
+  | image.pullPolicy    | 镜像拉取策略，由于本地存在cluster-resources项目镜像所以默认Never | Never    |
+  | image.tag           | 镜像版本                                                     | latest   |
+  | credentials.enabled | 证书挂载目录，默认关闭                                       | false    |
+
+  
+
+  *mariadb配置参数*
+
+  | **Name**                              | Description                                                  | Value     |
+  | ------------------------------------- | ------------------------------------------------------------ | --------- |
+  | mariadb.auth.rootPassword             | redis架构。允许值：`standalone`或`replication`               | root      |
+  | mariadb.primary.service.type=NodePort | mariadb服务暴露的方式（建议选NodePort，有个sql初始化脚本需要执行） | NodePort  |
+  | mariadb.initdbScriptsConfigMap        | ConfigMap with the initdb scripts                            | initdb_cm |
+  | mariadb.auth.database                 | Name for a custom database to create                         | bscp      |
+
+  *redis配置参数*
+
+  | **Name**                  | Description                                    | Value      |
+  | ------------------------- | ---------------------------------------------- | ---------- |
+  | redis.architecture        | redis架构。允许值：`standalone`或`replication` | standalone |
+  | redis.auth.enabled        | 启用密码验证                                   | false      |
+  | redis.auth.password       | root账号密码                                   |            |
+  | redis.master.service.type | 服务暴露的方式                                 | ClusterIP  |
+
+  *etcd配置参数*
+
+  | **Name**                 | Description                               | Value  |
+  | ------------------------ | ----------------------------------------- | ------ |
+  | etcd.replicaCount        | 要部署的etcd副本的数量                    | 1      |
+  | etcd.auth.rbac.create    | 启用RBAC认证                              | false  |
+  | etcd.auth.token.type     | 认证令牌类型。允许的值。'simple'或'jwt'。 | simple |
+  | etcd.persistence.enabled | 是否开启持久化                            | false  |
+
+- **安装bcs-bscp chart包**
+
+  ```
+  // 切换目录bcs-bscp chart目录
+  cd /data/workspace/src/bk-bcs/install/helm/bcs-bscp/
+  // ls命令确认下当前目录存在chart.yaml
+  // 安装chart包, 执行helm install（部署到默认的命名空间或者加上 -n 名称，指定命名空间）
+  
+  helm install -n bcs-bscp bcs-bscp   --debug ./
+  
+  // 首次部署该chart会提示需要依赖，执行一下
+  helm dependency build 
+  
+  // 再执行安装
+  helm install -n bcs-bscp bcs-bscp   --debug ./
+  
+  // 查看部署的状态
+  helm status bcs-cluster-resources -n default
+  ```
+
+
+

--- a/install/helm/bcs-bscp/sql/20230207215606_init_schema_down.sql
+++ b/install/helm/bcs-bscp/sql/20230207215606_init_schema_down.sql
@@ -1,0 +1,23 @@
+/*
+删除初始化migration所创建的所有表
+删除顺序与创建顺序相反，避免出现类似' referenced by a foreign key constraint '的报错
+*/
+
+drop table if exists `resource_lock`;
+drop table if exists `strategy_set`;
+drop table if exists `published_strategy_history`;
+drop table if exists `current_published_strategy`;
+drop table if exists `strategy`;
+drop table if exists `released_config_item`;
+drop table if exists `releases`;
+drop table if exists `current_released_instance`;
+drop table if exists `event`;
+drop table if exists `audit`;
+drop table if exists `content`;
+drop table if exists `config_item`;
+drop table if exists `commits`;
+drop table if exists `application`;
+drop table if exists `archived_app`;
+drop table if exists `id_generator`;
+drop table if exists `sharding_biz`;
+drop table if exists `sharding_db`;

--- a/install/helm/bcs-bscp/sql/20230207215606_init_schema_up.sql
+++ b/install/helm/bcs-bscp/sql/20230207215606_init_schema_up.sql
@@ -1,0 +1,572 @@
+/*
+表结构说明：
+各类模型表字段信息主要分为：
+1. 主键id                        // 由 id_generator 表来管理当前模型的id最大值，用来实现主键id自增功能
+3. 模型特定字段信息Spec            // 需要用户特殊定义的字段 (Spec)
+2. 外键id                        // 和当前模型有关联关系的模型主键id (Attachment)
+4. 关联模型特定字段信息Spec        // 当前模型需要记录有关联关系的模型特定字段信息 (OtherSpec)
+5. 创建信息（CreatedRevision）、创建及修正信息（Revision）
+
+注:
+    1. 字段说明统一参照 pkg/dal/table 目录下的数据结构定义说明。
+    2. varchar字符类型实际存储大小为 Len + 存储长度大小(1/2字节)，但是索引是根据设定的varchar长度进行建立的，
+    如需要对字段建立索引，注意存储消耗。varchar类型字段长度从小于255范围，扩展到大于255范围，因为记录varchar
+    实际长度的字符需要从 1byte -> 2byte，会进行锁表。所以，表字段跨255范围扩展，需确认影响。
+    3. 各类表的name以及namespace字段采用varchar第一范围最大值(255)进行存储，memo字段采用第二范围最小值(256)进行存储，
+    非必要禁止跨界。
+
+Sql语句规范：
+1. 字段需要按照上述分类进行排序和分类。
+*/
+
+# bk_bscp_admin is bscp system admin database, only save sharding_db、sharding_biz、id_generator table.
+
+create table if not exists `sharding_db`
+(
+    `id`         bigint(1) unsigned   not null auto_increment,
+
+    # Spec is a collection of resource's specifics defined with user
+    `type`       varchar(20)          not null,
+    `host`       varchar(64)          not null,
+    `port`       smallint(1) unsigned not null,
+    `user`       varchar(32)          not null,
+    `password`   varchar(32)          not null,
+    `database`   varchar(20)          not null,
+    `memo`       varchar(256)       default '',
+
+    # Revision record this resource's revision information
+    `creator`    varchar(64)          not null,
+    `reviser`    varchar(64)          not null,
+    `created_at` datetime(6)          not null,
+    `updated_at` datetime(6)          not null,
+
+    # Reserve reserve field.
+    `reservedA`  varchar(255)       default '',
+    `reservedB`  varchar(255)       default '',
+    `reservedC`  bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_host_port_user_passwd_db` (`host`, `port`, `user`, `password`, `database`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `sharding_biz`
+(
+    `id`             bigint(1) unsigned not null auto_increment,
+
+    # Spec is a collection of resource's specifics defined with user
+    `memo`           varchar(256)       default '',
+
+    # Attachment is a resource attachment id
+    `biz_id`         bigint(1) unsigned not null,
+    `sharding_db_id` bigint(1) unsigned not null,
+
+    # Revision record this resource's revision information
+    `creator`        varchar(64)        not null,
+    `reviser`        varchar(64)        not null,
+    `created_at`     datetime(6)        not null,
+    `updated_at`     datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`      varchar(255)       default '',
+    `reservedB`      varchar(255)       default '',
+    `reservedC`      bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    foreign key (`sharding_db_id`) references sharding_db (id),
+    unique key `idx_bizID_dbID` (`biz_id`, `sharding_db_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `id_generator`
+(
+    `id`         bigint(1) unsigned not null auto_increment,
+    `resource`   varchar(50)        not null,
+    `max_id`     bigint(1) unsigned not null,
+    `updated_at` datetime(6)        not null,
+
+    primary key (`id`),
+    unique key `idx_resource` (`resource`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+insert into id_generator(id, resource, max_id, updated_at)
+values (1, 'application', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (2, 'archived_app', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (3, 'commits', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (4, 'config_item', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (5, 'content', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (6, 'audit', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (7, 'event', 500, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (8, 'current_released_instance', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (9, 'releases', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (10, 'released_config_item', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (11, 'strategy', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (12, 'current_published_strategy', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (13, 'published_strategy_history', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (14, 'strategy_set', 0, now());
+insert into id_generator(id, resource, max_id, updated_at)
+values (15, 'resource_lock', 0, now());
+
+create table if not exists `archived_app`
+(
+    `id`         bigint(1) unsigned not null,
+    `biz_id`     bigint(1) unsigned not null,
+    `app_id`     bigint(1) unsigned not null,
+    `created_at` datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`  varchar(255)       default '',
+    `reservedB`  varchar(255)       default '',
+    `reservedC`  bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_bizID_appID` (`biz_id`, `app_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `application`
+(
+    `id`               bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `name`             varchar(255)       not null,
+    `config_type`      varchar(20)        not null,
+    `mode`             varchar(20)        not null,
+    `memo`             varchar(256)       default '',
+    `reload_type`      varchar(20)        default '',
+    `reload_file_path` varchar(255)       default '',
+
+    # Attachment is a resource attachment id
+    `biz_id`           bigint(1) unsigned not null,
+
+    # Revision record this resource's revision information
+    `creator`          varchar(64)        not null,
+    `reviser`          varchar(64)        not null,
+    `created_at`       datetime(6)        not null,
+    `updated_at`       datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`        varchar(255)       default '',
+    `reservedB`        varchar(255)       default '',
+    `reservedC`        bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_bizID_name` (`biz_id`, `name`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `commits`
+(
+    `id`             bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `content_id`     bigint(1) unsigned not null,
+    `signature`      varchar(64)        not null,
+    `byte_size`      bigint(1) unsigned not null,
+    `memo`           varchar(256)       default '',
+
+    # Attachment is a resource attachment id
+    `biz_id`         bigint(1) unsigned not null,
+    `app_id`         bigint(1) unsigned not null,
+    `config_item_id` bigint(1) unsigned not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`        varchar(64)        not null,
+    `created_at`     datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`      varchar(255)       default '',
+    `reservedB`      varchar(255)       default '',
+    `reservedC`      bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    index `idx_bizID_appID_cfgID` (`biz_id`, `app_id`, `config_item_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `config_item`
+(
+    `id`         bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `name`       varchar(255)       not null,
+    `path`       varchar(255)       not null,
+    `file_type`  varchar(20)        not null,
+    `file_mode`  varchar(20)        not null,
+    `memo`       varchar(256)       default '',
+    `user`       varchar(64)        not null,
+    `user_group` varchar(64)        not null,
+    `privilege`  varchar(64)        not null,
+
+    # Attachment is a resource attachment id
+    `biz_id`     bigint(1) unsigned not null,
+    `app_id`     bigint(1) unsigned not null,
+
+    # Revision record this resource's revision information
+    `creator`    varchar(64)        not null,
+    `reviser`    varchar(64)        not null,
+    `created_at` datetime(6)        not null,
+    `updated_at` datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`  varchar(255)       default '',
+    `reservedB`  varchar(255)       default '',
+    `reservedC`  bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_bizID_appID_name` (`biz_id`, `app_id`, `path`, `name`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `content`
+(
+    `id`             bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `signature`      varchar(64)        not null,
+    `byte_size`      bigint(1) unsigned not null,
+
+    # Attachment is a resource attachment id
+    `biz_id`         bigint(1) unsigned not null,
+    `app_id`         bigint(1) unsigned not null,
+    `config_item_id` bigint(1) unsigned not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`        varchar(64)        not null,
+    `created_at`     datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`      varchar(255)       default '',
+    `reservedB`      varchar(255)       default '',
+    `reservedC`      bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    index `idx_bizID_appID_cfgID` (`biz_id`, `app_id`, `config_item_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `audit`
+(
+    `id`         bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `res_type`   varchar(50)        not null,
+    `res_id`     bigint(1) unsigned not null,
+    `action`     varchar(20)        not null,
+    `rid`        varchar(64)        not null,
+    `app_code`   varchar(64)        not null,
+    `detail`     json               default null,
+
+    # Attachment is a resource attachment id
+    `biz_id`     bigint(1) unsigned not null,
+    `app_id`     bigint(1) unsigned default null,
+
+    `operator`   varchar(64)        not null,
+    `created_at` datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`  varchar(255)       default '',
+    `reservedB`  varchar(255)       default '',
+    `reservedC`  bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    key `idx_resType` (`res_type`),
+    key `idx_resID` (`res_id`),
+    key `idx_action` (`action`),
+    key `idx_createdAt` (`created_at`),
+    key `idx_bizID_appID_createdAt` (`biz_id`, `app_id`, `created_at`),
+    key `idx_bizID_resType_createdAt` (`biz_id`, `res_type`, `created_at`),
+    key `idx_bizID_operator_createdAt` (`biz_id`, `operator`, `created_at`),
+    key `idx_appCode_operator_createdAt` (`app_code`, `operator`, `created_at`)
+) engine = innodb
+  default charset = utf8mb4;
+
+create table if not exists `event`
+(
+    `id`           bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+                                                                                                     `resource`     varchar(50)        not null,
+    `op_type`      varchar(20)        not null,
+    `resource_id`  bigint(1) unsigned default 0,
+    `resource_uid` varchar(64)        default '',
+
+    `final_status` tinyint unsigned   default 0,
+
+    `biz_id`       bigint(1) unsigned not null,
+    `app_id`       bigint(1) unsigned not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`      varchar(64)        not null,
+    `created_at`   datetime(6)        not null,
+
+    primary key (`id`),
+    index `idx_resource_bizID` (`resource`, `biz_id`),
+    index `idx_createdAt` (`created_at`)
+) engine = innodb
+  default charset = utf8mb4;
+
+create table if not exists `current_released_instance`
+(
+    `id`         bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+                                                                                                     `uid`        varchar(64)        not null,
+    `release_id` bigint(1) unsigned not null,
+    `memo`       varchar(256)       default '',
+
+    # Attachment is a resource attachment id
+    `biz_id`     bigint(1) unsigned not null,
+    `app_id`     bigint(1) unsigned not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`    varchar(64)        not null,
+    `created_at` datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`  varchar(255)       default '',
+    `reservedB`  varchar(255)       default '',
+    `reservedC`  bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_appID_uid` (`app_id`, `uid`),
+    index `idx_uid` (`uid`),
+    index `idx_bizID_appID` (`biz_id`, `app_id`)
+) engine = innodb
+  default charset = utf8mb4;
+
+create table if not exists `releases`
+(
+    `id`         bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+                                                                                                     `name`       varchar(255)       not null,
+    `memo`       varchar(256)       default '',
+
+    # Attachment is a resource attachment id
+    `biz_id`     bigint(1) unsigned not null,
+    `app_id`     bigint(1) unsigned not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`    varchar(64)        not null,
+    `created_at` datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`  varchar(255)       default '',
+    `reservedB`  varchar(255)       default '',
+    `reservedC`  bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    index `idx_bizID_appID` (`biz_id`, `app_id`)
+) engine = innodb
+  default charset = utf8mb4;
+
+create table if not exists `released_config_item`
+(
+    `id`             bigint(1) unsigned not null,
+
+    `commit_id`      bigint(1) unsigned not null,
+    `release_id`     bigint(1) unsigned not null,
+
+    # Attachment is a resource attachment id
+    `biz_id`         bigint(1) unsigned not null,
+    `app_id`         bigint(1) unsigned not null,
+    `config_item_id` bigint(1) unsigned not null,
+
+    # Commit Spec
+    `content_id`     bigint(1) unsigned not null,
+    `signature`      varchar(64)        not null,
+    `byte_size`      bigint(1) unsigned not null,
+
+    # Config Item Spec
+    `name`           varchar(255)       not null,
+    `path`           varchar(255)       not null,
+    `file_type`      varchar(20)        not null,
+    `file_mode`      varchar(20)        not null,
+    `memo`           varchar(256)       default '',
+    `user`           varchar(64)        not null,
+    `user_group`     varchar(64)        not null,
+    `privilege`      varchar(64)        not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`        varchar(64)        not null,
+    `created_at`     datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`      varchar(255)       default '',
+    `reservedB`      varchar(255)       default '',
+    `reservedC`      bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_releaseID_commitID` (`release_id`, `commit_id`),
+    index `idx_bizID_appID` (`biz_id`, `app_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `strategy`
+(
+    `id`              bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `name`            varchar(255)       not null,
+    `release_id`      bigint(1) unsigned not null,
+    `as_default`      boolean            not null,
+    `scope`           json               default null,
+    `mode`            varchar(20)        not null,
+    `namespace`       varchar(128)       default '',
+    `memo`            varchar(256)       default '',
+    `pub_state`       varchar(20)        not null,
+
+    # Attachment is a resource attachment id
+    `biz_id`          bigint(1) unsigned not null,
+    `app_id`          bigint(1) unsigned not null,
+    `strategy_set_id` bigint(1) unsigned not null,
+
+    # Revision record this resource's revision information
+    `creator`         varchar(64)        not null,
+    `reviser`         varchar(64)        not null,
+    `created_at`      datetime(6)        not null,
+    `updated_at`      datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`       varchar(255)       default '',
+    `reservedB`       varchar(255)       default '',
+    `reservedC`       bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_setID_name` (`strategy_set_id`, `name`),
+    index `idx_bizID_appID` (`biz_id`, `app_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `current_published_strategy`
+(
+    `id`              bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `name`            varchar(255)       not null,
+    `release_id`      bigint(1) unsigned not null,
+    `as_default`      boolean            not null,
+    `scope`           json               default null,
+    `mode`            varchar(20)        not null,
+    `namespace`       varchar(128)       default '',
+    `memo`            varchar(256)       default '',
+    `pub_state`       varchar(20)        not null,
+
+    # Attachment is a resource attachment id
+    `biz_id`          bigint(1) unsigned not null,
+    `app_id`          bigint(1) unsigned not null,
+    `strategy_set_id` bigint(1) unsigned not null,
+    `strategy_id`     bigint(1) unsigned not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`         varchar(64)        not null,
+    `created_at`      datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`       varchar(255)       default '',
+    `reservedB`       varchar(255)       default '',
+    `reservedC`       bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_strategyID` (`strategy_id`),
+    index `idx_appID` (`app_id`),
+    index `idx_bizID_appID` (`biz_id`, `app_id`),
+    index `idx_bizID_releaseID` (`biz_id`, `release_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `published_strategy_history`
+(
+    `id`              bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `name`            varchar(255)       not null,
+    `release_id`      bigint(1) unsigned not null,
+    `as_default`      boolean            not null,
+    `scope`           json               default null,
+    `mode`            varchar(20)        not null,
+    `namespace`       varchar(128)       default '',
+    `memo`            varchar(256)       default '',
+    `pub_state`       varchar(20)        not null,
+
+    # Attachment is a resource attachment id
+    `biz_id`          bigint(1) unsigned not null,
+    `app_id`          bigint(1) unsigned not null,
+    `strategy_set_id` bigint(1) unsigned not null,
+    `strategy_id`     bigint(1) unsigned not null,
+
+    # CreatedRevision is a resource's reversion information being created.
+    `creator`         varchar(64)        not null,
+    `created_at`      datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`       varchar(255)       default '',
+    `reservedB`       varchar(255)       default '',
+    `reservedC`       bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    index `idx_bizID_appID_setID_strategyID` (`biz_id`, `app_id`, `strategy_set_id`, `strategy_id`),
+    index `idx_bizID_appID_setID_namespace` (`biz_id`, `app_id`, `strategy_set_id`, `namespace`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `strategy_set`
+(
+    `id`         bigint(1) unsigned not null,
+
+    # Spec is a collection of resource's specifics defined with user
+    `name`       varchar(255)       not null,
+    `mode`       varchar(20)        not null,
+    `status`     varchar(20)        default '',
+    `memo`       varchar(256)       default '',
+
+    # Attachment is a resource attachment id
+    `biz_id`     bigint(1) unsigned not null,
+    `app_id`     bigint(1) unsigned not null,
+
+    # Revision record this resource's revision information
+    `creator`    varchar(64)        not null,
+    `reviser`    varchar(64)        not null,
+    `created_at` datetime(6)        not null,
+    `updated_at` datetime(6)        not null,
+
+    # Reserve reserve field.
+    `reservedA`  varchar(255)       default '',
+    `reservedB`  varchar(255)       default '',
+    `reservedC`  bigint(1) unsigned default 0,
+
+    primary key (`id`),
+    unique key `idx_appID_name` (`app_id`, `name`),
+    unique key `idx_bizID_id` (`biz_id`, `id`),
+    index `idx_bizID_appID` (`biz_id`, `app_id`)
+    ) engine = innodb
+    default charset = utf8mb4;
+
+create table if not exists `resource_lock`
+(
+    `id`        bigint(1) unsigned not null auto_increment,
+    `res_type`  varchar(50)        not null,
+    `res_key`   varchar(512)       not null,
+    `res_count` bigint(1) unsigned not null,
+
+    `biz_id`    bigint(1) unsigned not null,
+
+    primary key (`id`),
+    unique key `idx_bizID_resType_resKey` (`biz_id`, `res_type`, `res_key`)
+    ) engine = innodb
+    default charset = utf8mb4;

--- a/install/helm/bcs-bscp/templates/_helpers.tpl
+++ b/install/helm/bcs-bscp/templates/_helpers.tpl
@@ -83,13 +83,3 @@ Create the name of the service account to use
         fieldPath: status.podIPs
 {{- end }}
 
-{{- define "bcs-bscp.volumes" -}}
-- name: POD_IP
-    valueFrom:
-    fieldRef:
-        fieldPath: status.podIP
-- name: POD_IPs # ipv6双栈
-    valueFrom:
-    fieldRef:
-        fieldPath: status.podIPs
-{{- end }}

--- a/install/helm/bcs-bscp/templates/configmap.yaml
+++ b/install/helm/bcs-bscp/templates/configmap.yaml
@@ -21,3 +21,4 @@ metadata:
 data:
   bcs_bscp_ui.yaml: |
     {{- toYaml .Values.ui_config | nindent 4 }}
+

--- a/install/helm/bcs-bscp/templates/deployment-apiserver.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-apiserver.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: bcsEtcdHost
-              value: "{{ include "bcs-common.etcd.host" ( dict "localStorage" .Values.storage "globalStorage" .Values.global.storage "namespace" .Release.Namespace ) }}"
+              value: bcs-bscp-etcd:2379
           ports:
             - name: http
               containerPort: 8080

--- a/install/helm/bcs-bscp/templates/deployment-authserver.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-authserver.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: bcsEtcdHost
-              value: "{{ include "bcs-common.etcd.host" ( dict "localStorage" .Values.storage "globalStorage" .Values.global.storage "namespace" .Release.Namespace ) }}"
+              value: bcs-bscp-etcd:2379
           ports:
             - name: grpc
               containerPort: 9513
@@ -73,14 +73,17 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /etc/bcs-bscp
+          {{- if eq .Values.credentials.enabled true }}
           - name: etcd-certs
             mountPath: /data/bcs/cert/etcd
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: config
         configMap:
           name: bcs-bscp
+      {{- if eq .Values.credentials.enabled true }}
       - name: etcd-certs
         projected:
           defaultMode: 420
@@ -94,6 +97,7 @@ spec:
               - key: tls.key
                 path: etcd-key.pem
               name: bcs-etcd-certs
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/bcs-bscp/templates/deployment-cacheservice.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-cacheservice.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: bcsEtcdHost
-              value: "{{ include "bcs-common.etcd.host" ( dict "localStorage" .Values.storage "globalStorage" .Values.global.storage "namespace" .Release.Namespace ) }}"
+              value: bcs-bscp-etcd:2379
           ports:
             - name: grpc
               containerPort: 9514
@@ -72,14 +72,17 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /etc/bcs-bscp
+          {{- if eq .Values.credentials.enabled true }}
           - name: etcd-certs
             mountPath: /data/bcs/cert/etcd
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: config
         configMap:
           name: bcs-bscp
+      {{- if eq .Values.credentials.enabled true }}
       - name: etcd-certs
         projected:
           defaultMode: 420
@@ -93,6 +96,7 @@ spec:
               - key: tls.key
                 path: etcd-key.pem
               name: bcs-etcd-certs
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/bcs-bscp/templates/deployment-configserver.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-configserver.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: bcsEtcdHost
-              value: "{{ include "bcs-common.etcd.host" ( dict "localStorage" .Values.storage "globalStorage" .Values.global.storage "namespace" .Release.Namespace ) }}"
+              value: bcs-bscp-etcd:2379
           ports:
             - name: grpc
               containerPort: 9512
@@ -72,14 +72,17 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /etc/bcs-bscp
+          {{- if eq .Values.credentials.enabled true }}
           - name: etcd-certs
             mountPath: /data/bcs/cert/etcd
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: config
         configMap:
           name: bcs-bscp
+      {{- if eq .Values.credentials.enabled true }}
       - name: etcd-certs
         projected:
           defaultMode: 420
@@ -93,6 +96,7 @@ spec:
               - key: tls.key
                 path: etcd-key.pem
               name: bcs-etcd-certs
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/bcs-bscp/templates/deployment-dataservice.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-dataservice.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: bcsEtcdHost
-              value: "{{ include "bcs-common.etcd.host" ( dict "localStorage" .Values.storage "globalStorage" .Values.global.storage "namespace" .Release.Namespace ) }}"
+              value: bcs-bscp-etcd:2379
           ports:
             - name: grpc
               containerPort: 9511
@@ -72,14 +72,17 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /etc/bcs-bscp
+          {{- if eq .Values.credentials.enabled true }}
           - name: etcd-certs
             mountPath: /data/bcs/cert/etcd
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: config
         configMap:
           name: bcs-bscp
+      {{- if eq .Values.credentials.enabled true }}
       - name: etcd-certs
         projected:
           defaultMode: 420
@@ -93,6 +96,7 @@ spec:
               - key: tls.key
                 path: etcd-key.pem
               name: bcs-etcd-certs
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/bcs-bscp/templates/deployment-feedserver.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-feedserver.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:
@@ -47,7 +47,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIPs
             - name: bcsEtcdHost
-              value: "{{ include "bcs-common.etcd.host" ( dict "localStorage" .Values.storage "globalStorage" .Values.global.storage "namespace" .Release.Namespace ) }}"
+              value: bcs-bscp-etcd:2379
           ports:
             - name: grpc
               containerPort: 9510
@@ -73,14 +73,17 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /etc/bcs-bscp
+          {{- if eq .Values.credentials.enabled true }}
           - name: etcd-certs
             mountPath: /data/bcs/cert/etcd
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: config
         configMap:
           name: bcs-bscp
+      {{- if eq .Values.credentials.enabled true }}
       - name: etcd-certs
         projected:
           defaultMode: 420
@@ -94,6 +97,7 @@ spec:
               - key: tls.key
                 path: etcd-key.pem
               name: bcs-etcd-certs
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/bcs-bscp/templates/deployment-sidecar.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-sidecar.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:
@@ -67,14 +67,17 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /etc/bcs-bscp
+          {{- if eq .Values.credentials.enabled true }}
           - name: etcd-certs
             mountPath: /data/bcs/cert/etcd
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
       - name: config
         configMap:
           name: bcs-bscp
+      {{- if eq .Values.credentials.enabled true }}
       - name: etcd-certs
         projected:
           defaultMode: 420
@@ -88,6 +91,7 @@ spec:
               - key: tls.key
                 path: etcd-key.pem
               name: bcs-etcd-certs
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/bcs-bscp/templates/deployment-ui.yaml
+++ b/install/helm/bcs-bscp/templates/deployment-ui.yaml
@@ -35,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: bcs-bscp:latest
+          imagePullPolicy: Never
           env:
             - name: POD_IP
               valueFrom:

--- a/install/helm/bcs-bscp/templates/mariadb_cm.yaml
+++ b/install/helm/bcs-bscp/templates/mariadb_cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bcs-bscp-mariadb-initscripts
+  labels:
+    app: bcs-bscp-mariadb
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+data:
+  {{ (.Files.Glob "sql/20230207215606_init_schema_up.sql").AsConfig | indent 2 }}

--- a/install/helm/bcs-bscp/templates/service-apiserver.yaml
+++ b/install/helm/bcs-bscp/templates/service-apiserver.yaml
@@ -6,12 +6,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: bcs-bscp-apiserver
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
     - port: 8080
       targetPort: http
       protocol: TCP
       name: http
+      nodePort: 32199
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: bcs-bscp-apiserver

--- a/install/helm/bcs-bscp/templates/service-ui.yaml
+++ b/install/helm/bcs-bscp/templates/service-ui.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: bcs-bscp-ui
 spec:
-  type: {{ .Values.service.type }}
+  type: NodePort
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/install/helm/bcs-bscp/values.yaml
+++ b/install/helm/bcs-bscp/values.yaml
@@ -3,7 +3,8 @@ global:
   # etcd 依赖配置
   storage:
     etcd:
-      endpoints: []
+      endpoints:
+        - bcs-bscp-etcd:2379
   secret:
     autoGenerate: true
     #bcs server cert
@@ -20,7 +21,8 @@ global:
 # etcd 依赖配置
 storage:
   etcd:
-    endpoints: []
+    endpoints:
+      - bcs-bscp-etcd:2379
 
 replicaCount: 1
 
@@ -71,7 +73,7 @@ podAnnotations: {}
 
 podSecurityContext:
   {}
-  # fsGroup: 2000
+# fsGroup: 2000
 
 securityContext:
   {}
@@ -80,34 +82,90 @@ securityContext:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-  # runAsUser: 1000
+# runAsUser: 1000
 
 config:
+  log:
+    # log storage directory.
+    logDir: ./log
+    # per file max size, uint: MB.
+    maxPerFileSizeMB: 1024
+    # per line max size, uint: KB.
+    maxPerLineSizeKB: 2
+    # log file max storage number.
+    maxFileNum: 5
+    # whether the restart service log is appended to the latest log file, or whether a new log file is created.
+    logAppend: false
+    # log the log to std err only, it can not be used with AlsoToStdErr at the same time.
+    toStdErr: true
+    # log the log to file and also to std err. it can not be used with ToStdErr at the same time.
+    alsoToStdErr: false
+    # log level.
+    verbosity: 1
   service:
     etcd:
       endpoints:
-        - bcs-etcd:2379
+        - bcs-bscp-etcd:2379
       tls:
         certFile:
         keyFile:
         caFile:
+  # data server
+  esb:
+    endpoints:
+      -
+    # appCode is the blueking app code of bscp to request esb.
+    appCode:
+    # appSecret is the blueking app secret of bscp to request esb.
+    appSecret:
+    user:
 
   sharding:
     adminDatabase:
-      endpoints: 127.0.0.1:3306
-      database:
-      user:
-      password:
+      endpoints:
+        - bcs-bscp-mariadb:3306
+      database: bscp
+      user: root
+      password: root
     maxSlowLogLatencyMS: 200
     limiter:
       qps: 500
       burst: 500
+  loginAuth:
+    host:
 
   redisCluster:
     endpoints:
-      - bcs-services-stack-redis-master:6379
+      - bcs-bscp-redis-master:6379
     password:
     db: 1
+
+  # feed server
+  repository:
+    endpoints: {}
+    token:
+    project:
+    user:
+    
+  downstream:
+    bounceIntervalHour: 48  #<=48
+
+  # sidecar
+  upstream:
+    endpoints:
+      - bcs-bscp-feedserver:9510
+    authentication:
+      user: bcs-bscp
+      token: bcs-bscp
+  appSpec:
+    bizID: 2 # 蓝鲸项目
+    applications:
+      - appID: 1 # 手动调用API创建
+        namespace: ""
+        uid: 10
+  workspace:
+    rootDirectory: /tmp
+
 
 ui_config:
   base_conf:
@@ -115,7 +173,7 @@ ui_config:
     app_secret: ""
     time_zone: Asia/Shanghai
     language_code: en
-    run_env: prod
+    run_env: dev
 
   bcs_conf:
     host: ""
@@ -128,11 +186,18 @@ ui_config:
     preferred_domains: ""
 
   etcd:
-    endpoints: bcs-etcd.bcs-system.svc.cluster.local:2379
+    endpoints: bcs-bscp-etcd:2379
     ca: ""
     cert: ""
     key: ""
+  
+  loginAuth:
+    host:
 
+  frontend_conf:
+    hosts:
+      devops_bcs_api_url: 
+  
 service:
   type: ClusterIP
   port: 80
@@ -143,7 +208,7 @@ ingress:
   annotations:
     {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -174,3 +239,37 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+
+credentials:
+  enabled: false
+
+
+redis:
+  architecture: standalone
+  auth:
+    enabled: false
+    #auth.enable 为true可配置密码
+    password:
+  master:
+    service:
+      type: NodePort
+
+etcd:
+  replicaCount: 1
+  auth:
+    rbac:
+      create: false
+    token:
+      type: simple
+  persistence:
+    enabled: false
+
+mariadb:
+  auth:
+    rootPassword: root
+    database: bscp
+  primary:
+    service:
+      type: NodePort
+  initdbScriptsConfigMap: bcs-bscp-mariadb-initscripts  #配置初始化sql脚本，指定configmapName


### PR DESCRIPTION
1.提供部署文档包含依赖的mariadb、redis、etcd
2.mariadb添加初始化脚本功能，mariadb.initdbScriptsConfigMap配合configmap挂载初始化sql

[issue](https://github.com/Tencent/bk-bcs/issues/2001)