### PR TITLE
servicemonitor crud接口

### DIFF
--- a/bcs-services/bcs-monitor/go.mod
+++ b/bcs-services/bcs-monitor/go.mod
@@ -28,6 +28,8 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0
+	github.com/prometheus-operator/prometheus-operator/pkg/client v0.46.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/common v0.34.0
 	github.com/prometheus/prometheus v1.8.2-0.20220308163432-03831554a519
@@ -197,6 +199,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	helm.sh/helm/v3 v3.8.2 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
+	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	moul.io/http2curl v1.0.0 // indirect

--- a/bcs-services/bcs-monitor/pkg/api/routes.go
+++ b/bcs-services/bcs-monitor/pkg/api/routes.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/docs" // docs xxx
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/api/metrics"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/api/pod"
+	service_monitor "github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/api/servicemonitor"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/api/telemetry"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/config"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/rest"
@@ -190,6 +191,19 @@ func registerMetricsRoutes(engine *gin.RouterGroup) {
 			rest.RestHandlerFunc(metrics.ContainerDiskReadTotal))
 		route.GET("/namespaces/:namespace/pods/:pod/containers/:container/disk_write_total",
 			rest.RestHandlerFunc(metrics.ContainerDiskWriteTotal))
+
+		route.GET("/namespaces/:namespace/service_monitors",
+			rest.RestHandlerFunc(service_monitor.ListServiceMonitors))
+		route.GET("/namespaces/:namespace/service_monitors/:name",
+			rest.RestHandlerFunc(service_monitor.GetServiceMonitor))
+		route.POST("/namespaces/:namespace/service_monitors",
+			rest.RestHandlerFunc(service_monitor.CreateServiceMonitor))
+		route.PUT("/namespaces/:namespace/service_monitors/:name",
+			rest.RestHandlerFunc(service_monitor.UpdateServiceMonitor))
+		route.DELETE("/namespaces/:namespace/service_monitors/:name",
+			rest.RestHandlerFunc(service_monitor.DeleteServiceMonitor))
+		route.POST("/service_monitors/batchdelete",
+			rest.RestHandlerFunc(service_monitor.BatchDeleteServiceMonitor))
 	}
 }
 

--- a/bcs-services/bcs-monitor/pkg/api/servicemonitor/servicemonitor.go
+++ b/bcs-services/bcs-monitor/pkg/api/servicemonitor/servicemonitor.go
@@ -1,0 +1,318 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package service_monitor
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	v1client "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8srest "k8s.io/client-go/rest"
+
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/component/k8sclient"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-monitor/pkg/rest"
+)
+
+func GetMonitoringV1Client(c *rest.Context) (monitoringv1.MonitoringV1Interface, error) {
+	clusterId := c.Param("clusterId")
+	bcsConf := k8sclient.GetBCSConfByClusterId(clusterId)
+	host := fmt.Sprintf("%s/clusters/%s", bcsConf.Host, clusterId)
+	k8sconfig := &k8srest.Config{
+		Host:        host,
+		BearerToken: bcsConf.Token,
+	}
+	config, err := v1client.NewForConfig(k8sconfig)
+	if err != nil {
+		return nil, err
+	}
+	return config.MonitoringV1(), nil
+}
+
+// ListServiceMonitors 获取ServiceMonitor列表数据
+// @Summary ServiceMonitor列表数据
+// @Tags    Metrics
+// @Success 200 {string} string
+// @Router  /service_monitors/namespaces/:namespace [get]
+func ListServiceMonitors(c *rest.Context) (interface{}, error) {
+
+	limit := c.Query("limit")
+	offset := c.Query("offset")
+	client, err := GetMonitoringV1Client(c)
+	if err != nil {
+		return nil, err
+	}
+	var limitInt int
+	if limit != "" {
+		limitInt, err = strconv.Atoi(limit)
+		if err != nil {
+			return nil, err
+		}
+	}
+	listOps := metav1.ListOptions{
+		Limit:    int64(limitInt),
+		Continue: offset,
+	}
+	serviceMonitors, err := client.ServiceMonitors("").List(c.Context, listOps)
+	if err != nil {
+		return nil, err
+	}
+	return serviceMonitors, nil
+}
+
+// CreateServiceMonitor 创建ServiceMonitor
+// @Summary ServiceMonitor列表数据
+// @Tags    Metrics
+// @Success 200 {string} string
+// @Router  /service_monitors/create/namespaces/:namespace/servicemonitors/:name [post]
+func CreateServiceMonitor(c *rest.Context) (interface{}, error) {
+	serviceMonitorReq := &CreateServiceMonitorReq{}
+	if err := c.ShouldBindJSON(serviceMonitorReq); err != nil {
+		return nil, err
+	}
+	serviceMonitorReq.Name = serviceMonitorReq.ServiceName
+	serviceMonitorReq.Namespace = c.Param("namespace")
+
+	flag := serviceMonitorReq.Validate()
+
+	if !flag {
+		return nil, errors.New("参数校验失败")
+	}
+
+	client, err := GetMonitoringV1Client(c)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceMonitor := &v1.ServiceMonitor{}
+	labels := map[string]string{
+		"release":                     "po",
+		"io.tencent.paas.source_type": "bcs",
+		"io.tencent.bcs.service_name": serviceMonitorReq.ServiceName,
+	}
+
+	serviceMonitor.ObjectMeta = metav1.ObjectMeta{
+		Labels:    labels,
+		Name:      serviceMonitorReq.Name,
+		Namespace: serviceMonitorReq.Namespace,
+	}
+	endpoints := make([]v1.Endpoint, 0)
+	initEndpoint := v1.Endpoint{
+		Port:     serviceMonitorReq.Port,
+		Path:     serviceMonitorReq.Path,
+		Interval: strconv.FormatInt(int64(serviceMonitorReq.Interval), 10),
+	}
+
+	endpoints = append(endpoints, initEndpoint)
+	serviceMonitor.Spec = v1.ServiceMonitorSpec{
+		Endpoints:   endpoints,
+		SampleLimit: uint64(serviceMonitorReq.SampleLimit),
+		Selector: metav1.LabelSelector{
+			MatchLabels: serviceMonitorReq.Selector,
+		},
+	}
+
+	created, err := client.ServiceMonitors(serviceMonitorReq.Namespace).Create(c.Context, nil, metav1.CreateOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+// DeleteServiceMonitor 删除ServiceMonitor
+// @Summary 删除ServiceMonitor
+// @Tags    Metrics
+// @Success 200 {string} string
+// @Router  /service_monitors/namespaces/:namespace/servicemonitors/:name [delete]
+func DeleteServiceMonitor(c *rest.Context) (interface{}, error) {
+	name := c.Param("name")
+	flag := validateName(name)
+	if !flag {
+		return nil, fmt.Errorf("校验name参数: %s 是否符合k8s资源名称格式并且长度不大于63位字符不通过", name)
+	}
+	namespace := c.Param("namespace")
+	client, err := GetMonitoringV1Client(c)
+	if err != nil {
+		return nil, err
+	}
+	err = client.ServiceMonitors(namespace).Delete(c, name, metav1.DeleteOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return fmt.Sprintf("删除 Metrics: %s 成功", name), nil
+}
+
+// BatchDeleteServiceMonitor 批量删除ServiceMonitor
+// @Summary 批量删除ServiceMonitor
+// @Tags    Metrics
+// @Success 200 {string} string
+// @Router  /service_monitors/batchdelete [delete]
+func BatchDeleteServiceMonitor(c *rest.Context) (interface{}, error) {
+	serviceMonitorDelReq := BatchDeleteServiceMonitorReq{}
+	if err := c.ShouldBindJSON(serviceMonitorDelReq); err != nil {
+		return nil, err
+	}
+	client, err := GetMonitoringV1Client(c)
+	if err != nil {
+		return nil, err
+	}
+	for i := range serviceMonitorDelReq.ServiceMonitors {
+		err = client.ServiceMonitors(serviceMonitorDelReq.ServiceMonitors[i].Namespace).Delete(c, serviceMonitorDelReq.ServiceMonitors[i].Name, metav1.DeleteOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return fmt.Sprintf("批量删除 Metrics: %s 成功", serviceMonitorDelReq), nil
+}
+
+// GetServiceMonitor 获取单个ServiceMonitor
+// @Summary 删除ServiceMonitor
+// @Tags    Metrics
+// @Success 200 {string} string
+// @Router  /service_monitors/namespaces/:namespace/servicemonitors/:name [delete]
+func GetServiceMonitor(c *rest.Context) (interface{}, error) {
+	name := c.Param("name")
+	flag := validateName(name)
+	if !flag {
+		return nil, fmt.Errorf("校验name参数: %s 是否符合k8s资源名称格式并且长度不大于63位字符不通过", name)
+	}
+	namespace := c.Param("namespace")
+	client, err := GetMonitoringV1Client(c)
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.ServiceMonitors(namespace).Get(c.Context, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// UpdateServiceMonitor 创建ServiceMonitor
+// @Summary ServiceMonitor列表数据
+// @Tags    Metrics
+// @Success 200 {string} string
+// @Router  /service_monitors/update/namespaces/:namespace/servicemonitors/:name [put]
+func UpdateServiceMonitor(c *rest.Context) (interface{}, error) {
+	serviceMonitorReq := &UpdateServiceMonitorReq{}
+	if err := c.ShouldBindJSON(serviceMonitorReq); err != nil {
+		return nil, err
+	}
+	serviceMonitorReq.Name = c.Param("name")
+	serviceMonitorReq.Namespace = c.Param("namespace")
+
+	flag := serviceMonitorReq.Validate()
+
+	if !flag {
+		return nil, errors.New("参数校验失败")
+	}
+
+	client, err := GetMonitoringV1Client(c)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceMonitor := &v1.ServiceMonitor{}
+	labels := map[string]string{
+		"release":                     "po",
+		"io.tencent.paas.source_type": "bcs",
+		"io.tencent.bcs.service_name": serviceMonitorReq.ServiceName,
+	}
+
+	serviceMonitor.ObjectMeta = metav1.ObjectMeta{
+		Labels:    labels,
+		Name:      serviceMonitorReq.Name,
+		Namespace: serviceMonitorReq.Namespace,
+	}
+	endpoints := make([]v1.Endpoint, 0)
+	initEndpoint := v1.Endpoint{
+		Port:     serviceMonitorReq.Port,
+		Path:     serviceMonitorReq.Path,
+		Interval: strconv.FormatInt(int64(serviceMonitorReq.Interval), 10),
+	}
+
+	endpoints = append(endpoints, initEndpoint)
+	serviceMonitor.Spec = v1.ServiceMonitorSpec{
+		Endpoints:   endpoints,
+		SampleLimit: uint64(serviceMonitorReq.SampleLimit),
+		Selector: metav1.LabelSelector{
+			MatchLabels: serviceMonitorReq.Selector,
+		},
+	}
+	serviceMonitorClient := client.ServiceMonitors(serviceMonitorReq.Namespace)
+	updated, err := serviceMonitorClient.Update(c.Context, serviceMonitor, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// validateName 校验name参数是否符合k8s资源名称格式并且长度不大于63位字符
+func validateName(name string) bool {
+	if len(name) > 63 {
+		return false
+	}
+	//第一个正则表达式 ^[a-z][-a-z0-9]*$ 匹配以小写字母开头，后跟任意数量的小写字母、数字和短横线的字符串。这个正则表达式不允许字符串末尾有短横线，因为 [-a-z0-9]* 匹配任意数量的小写字母、数字和短横线，但它不需要匹配任何字符。
+	//
+	//第二个正则表达式 ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ 匹配以小写字母或数字开头，后跟任意数量的小写字母、数字和短横线的字符串。它允许字符串末尾有短横线，因为 ([-a-z0-9]*[a-z0-9])? 匹配任意数量的小写字母、数字和短横线，后跟一个小写字母或数字，这个组合出现零次或一次，因此字符串末尾可以是短横线或小写字母或数字。
+	//              ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	//因此，虽然这两个正则表达式都匹配以小写字母或数字开头，后跟任意数量的小写字母、数字和短横线的字符串，但是第二个正则表达式允许字符串末尾有短横线，因此与第一个正则表达式不完全相同。
+	if match, _ := regexp.MatchString("^[a-z][-a-z0-9]*$", name); !match {
+		return false
+	}
+
+	return true
+}
+
+// validateInterval 校验参数是否合法，num必须是在常量切片定义的值
+func validateInterval(num int) bool {
+	for _, val := range intervalSlice {
+		if val == num {
+			//fmt.Printf("%d is in the slice\n", num)
+			return true
+		}
+	}
+	return false
+}
+
+// validatePath 校验参数是否合法，必须是绝对路径
+func validatePath(path string) bool {
+	if strings.HasPrefix(path, "/") {
+		return true
+	}
+	return false
+}
+
+// validatePath 校验参数是否合法，不可为空
+func validateSelector(selector map[string]string) bool {
+	if selector == nil || len(selector) == 0 {
+		return false
+	}
+	return true
+}
+
+// validateSampleLimit 校验参数是否合法
+func validateSampleLimit(samplelimit int) bool {
+	if SM_SAMPLE_LIMIT_MAX >= samplelimit && samplelimit >= SM_SAMPLE_LIMIT_MIN {
+		return true
+	}
+	return false
+}

--- a/bcs-services/bcs-monitor/pkg/api/servicemonitor/servicemonitor_types.go
+++ b/bcs-services/bcs-monitor/pkg/api/servicemonitor/servicemonitor_types.go
@@ -1,0 +1,77 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package service_monitor
+
+import (
+	"strconv"
+	"strings"
+)
+
+// 注意：常量定义的切片必须是升序排列的
+const INTERVAL_VALUE = "30,60,120"
+const SM_SAMPLE_LIMIT_MAX = 100000
+const SM_SAMPLE_LIMIT_MIN = 1
+
+var intervalSlice = func() []int {
+	s := make([]int, 0, len(strings.Split(INTERVAL_VALUE, ",")))
+	for _, v := range strings.Split(INTERVAL_VALUE, ",") {
+		i, _ := strconv.Atoi(v)
+		s = append(s, i)
+	}
+	return s
+}()
+
+type CreateServiceMonitorReq struct {
+	ServiceName string            `json:"service_name"`
+	Path        string            `json:"path"`
+	Selector    map[string]string `json:"selector"`
+	Interval    int               `json:"interval"`
+	Port        string            `json:"port"`
+	SampleLimit int               `json:"sample_limit"`
+	Namespace   string            `json:"namespace"`
+	Name        string            `json:"name"`
+}
+
+func (r CreateServiceMonitorReq) Validate() bool {
+	if validateName(r.Name) && validateInterval(r.Interval) && validatePath(r.Path) && validateSelector(r.Selector) && validateSampleLimit(r.SampleLimit) {
+		return true
+	}
+	return false
+}
+
+type BatchDeleteServiceMonitorReq struct {
+	ServiceMonitors []ServiceMonitor `json:"service_monitors"`
+}
+type ServiceMonitor struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+type UpdateServiceMonitorReq struct {
+	ServiceName string            `json:"service_name"`
+	Path        string            `json:"path"`
+	Selector    map[string]string `json:"selector"`
+	Interval    int               `json:"interval"`
+	Port        string            `json:"port"`
+	SampleLimit int               `json:"sample_limit"`
+	Namespace   string            `json:"namespace"`
+	Name        string            `json:"name"`
+}
+
+// Validate 校验参数
+func (r UpdateServiceMonitorReq) Validate() bool {
+	if validateName(r.Name) && validateInterval(r.Interval) && validatePath(r.Path) && validateSelector(r.Selector) && validateSampleLimit(r.SampleLimit) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
1.bcs-monitor 添加servicemonitor crud接口
2.servicemonitor结构体来源于github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0 高版本对gomod文件修改较多

https://github.com/TencentBlueKing/bk-bcs/issues/2032