### PR TITLE
fix: fix bscp orm page can not order when list all

### DIFF
--- a/bcs-services/bcs-bscp/pkg/types/page.go
+++ b/bcs-services/bcs-bscp/pkg/types/page.go
@@ -246,11 +246,6 @@ func (bp BasePage) SQLExpr(ps *PageSQLOption) (where string, err error) {
 		return "", errors.New("page.count is enabled, do not support generate SQL expression")
 	}
 
-	if bp.Start == 0 && bp.Limit == 0 {
-		// it means do not need to sort.
-		return "", nil
-	}
-
 	var sort string
 	if ps.Sort.ForceOverlap {
 		// force overlapped user defined sort field.


### PR DESCRIPTION
fix: fix bscp orm page can not order when list all