### PR TITLE
bcs-common新增gin tracing中间件

### DIFF
--- a/bcs-common/go.mod
+++ b/bcs-common/go.mod
@@ -101,6 +101,8 @@ require (
 	github.com/evanphx/json-patch/v5 v5.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/gin-gonic/gin v1.7.7 // indirect
 	github.com/go-acme/lego/v4 v4.4.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
@@ -139,6 +141,7 @@ require (
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20200820163806-098863c1fc24 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/micro/cli/v2 v2.1.2 // indirect
 	github.com/miekg/dns v1.1.50 // indirect

--- a/bcs-common/pkg/otel/trace/constants/constants.go
+++ b/bcs-common/pkg/otel/trace/constants/constants.go
@@ -1,0 +1,25 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package constants
+
+import "go.opentelemetry.io/otel/attribute"
+
+const (
+	// RequestIDKey xxx
+	RequestIDKey       = "requestID"
+	TracerKey          = "otel-go-contrib-tracer"
+	TracerName         = "go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+	RequestIDHeaderKey = "X-Request-Id"
+	GRPCStatusCodeKey  = attribute.Key("rpc.grpc.status_code")
+)

--- a/bcs-common/pkg/otel/trace/gin/middleware.go
+++ b/bcs-common/pkg/otel/trace/gin/middleware.go
@@ -1,0 +1,162 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package gin
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/otel/trace/constants"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/otel/trace/utils"
+	"github.com/dustin/go-humanize"
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// Middleware returns middleware that will trace incoming requests.
+// The service parameter should describe the name of the (virtual)
+// server handling the request.
+func Middleware(server string, opts ...Option) gin.HandlerFunc {
+	cfg := option{}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	if cfg.TracerProvider == nil {
+		cfg.TracerProvider = otel.GetTracerProvider()
+	}
+
+	// tracerName是检测库的包名
+	tracer := cfg.TracerProvider.Tracer(
+		constants.TracerName,
+		oteltrace.WithInstrumentationVersion(SemVersion()),
+	)
+	if cfg.Propagators == nil {
+		cfg.Propagators = otel.GetTextMapPropagator()
+	}
+
+	return func(c *gin.Context) {
+		// 开始时间
+		startTime := time.Now()
+		writer := responseWriter{
+			c.Writer,
+			bytes.NewBuffer([]byte{}),
+		}
+		c.Writer = writer
+
+		for _, f := range cfg.Filters {
+			if !f(c.Request) {
+				// Serve the request to the next middleware
+				// if a filter rejects the request.
+				c.Next()
+				return
+			}
+		}
+		c.Set(constants.TracerKey, tracer)
+		savedCtx := c.Request.Context()
+		defer func() {
+			c.Request = c.Request.WithContext(savedCtx)
+		}()
+		ctx := cfg.Propagators.Extract(savedCtx, propagation.HeaderCarrier(c.Request.Header))
+		requestID, _ := ctx.Value(constants.RequestIDHeaderKey).(string)
+		// 使用requestID当作TraceID
+		ctx = context.WithValue(ctx, constants.RequestIDKey, requestID)
+		ctx = utils.ContextWithRequestID(ctx, requestID)
+
+		// 记录额外的信息
+		commonAttrs := semconv.NetAttributesFromHTTPRequest("tcp", c.Request)
+		commonAttrs = append(commonAttrs, attribute.String("component", "http"))
+
+		opts := []oteltrace.SpanStartOption{
+			oteltrace.WithAttributes(commonAttrs...),
+			oteltrace.WithAttributes(semconv.EndUserAttributesFromHTTPRequest(c.Request)...),
+			oteltrace.WithAttributes(semconv.HTTPServerAttributesFromHTTPRequest(server, c.FullPath(), c.Request)...),
+			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+		}
+
+		spanName := c.FullPath()
+		if spanName == "" {
+			spanName = fmt.Sprintf("HTTP %s route not found", c.Request.Method)
+		}
+
+		ctx, span := tracer.Start(ctx, spanName, opts...)
+		defer span.End()
+
+		// 记录query参数
+		query := c.Request.URL.Query().Encode()
+		if len(query) > 1024 {
+			query = fmt.Sprintf("%s...(Total %s)", query[:1024], humanize.Bytes(uint64(len(query))))
+		}
+		span.SetAttributes(attribute.Key("query").String(query))
+
+		//记录body
+		body := string(getRequestBody(c.Request))
+		if len(body) > 1024 {
+			body = fmt.Sprintf("%s...(Total %s)", body[:1024], humanize.Bytes(uint64(len(body))))
+		}
+		span.SetAttributes(attribute.Key("body").String(body))
+
+		// pass the span through the request context
+		c.Request = c.Request.WithContext(ctx)
+
+		// serve the request to the next middleware
+		c.Next()
+
+		// 记录响应参数和响应时间
+		respBody := writer.b.String()
+		if len(respBody) > 1024 {
+			respBody = fmt.Sprintf("%s...(Total %s)", writer.b.String()[:1024], humanize.Bytes(uint64(len(writer.b.String()))))
+		}
+		span.SetAttributes(attribute.Key("rsp").String(respBody))
+		elapsedTime := time.Now().Sub(startTime)
+		span.SetAttributes(attribute.Key("elapsed_ime").String(elapsedTime.String()))
+
+		status := c.Writer.Status()
+		attrs := semconv.HTTPAttributesFromHTTPStatusCode(status)
+		spanStatus, spanMessage := semconv.SpanStatusFromHTTPStatusCode(status)
+		span.SetAttributes(attrs...)
+		span.SetStatus(spanStatus, spanMessage)
+		if len(c.Errors) > 0 {
+			span.SetAttributes(attribute.String("gin.errors", c.Errors.String()))
+		}
+	}
+}
+
+// 获取请求体
+func getRequestBody(r *http.Request) []byte {
+	// 读取请求体
+	body, _ := io.ReadAll(r.Body)
+	// 恢复请求体
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+	return body
+}
+
+type responseWriter struct {
+	gin.ResponseWriter
+	b *bytes.Buffer
+}
+
+func (w responseWriter) Write(b []byte) (int, error) {
+	//向一个bytes.buffer中写一份数据来为获取body使用
+	w.b.Write(b)
+	//完成gin.Context.Writer.Write()原有功能
+	return w.ResponseWriter.Write(b)
+}

--- a/bcs-common/pkg/otel/trace/gin/middleware_test.go
+++ b/bcs-common/pkg/otel/trace/gin/middleware_test.go
@@ -1,0 +1,79 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package gin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func init() {
+	gin.SetMode(gin.ReleaseMode) // silence annoying log msgs
+}
+
+func TestChildSpanFromGlobalTracer(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+
+	router := gin.New()
+	router.Use(Middleware("test"))
+	router.GET("/user/:id", func(c *gin.Context) {})
+
+	r := httptest.NewRequest("GET", "/user/123", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+	assert.Len(t, sr.Ended(), 1)
+}
+
+func TestWithFilter(t *testing.T) {
+	t.Run("custom filter filtering route", func(t *testing.T) {
+		sr := tracetest.NewSpanRecorder()
+		otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+
+		router := gin.New()
+		f := func(req *http.Request) bool { return req.URL.Path != "/healthcheck" }
+		router.Use(Middleware("test", WithFilter(f)))
+		router.GET("/healthcheck", func(c *gin.Context) {})
+
+		r := httptest.NewRequest("GET", "/healthcheck", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, r)
+		assert.Len(t, sr.Ended(), 0)
+	})
+
+	t.Run("custom filter not filtering route", func(t *testing.T) {
+		sr := tracetest.NewSpanRecorder()
+		otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+
+		router := gin.New()
+		f := func(req *http.Request) bool { return req.URL.Path != "/healthcheck" }
+		router.Use(Middleware("foobar", WithFilter(f)))
+		router.GET("/user/:id", func(c *gin.Context) {})
+
+		r := httptest.NewRequest("GET", "/user/123", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, r)
+		assert.Len(t, sr.Ended(), 1)
+	})
+}

--- a/bcs-common/pkg/otel/trace/gin/option.go
+++ b/bcs-common/pkg/otel/trace/gin/option.go
@@ -1,0 +1,87 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package gin
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel/propagation"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+type option struct {
+	TracerProvider    oteltrace.TracerProvider
+	Propagators       propagation.TextMapPropagator
+	Filters           []Filter
+	SpanNameFormatter SpanNameFormatter
+}
+
+// Filter is a predicate used to determine whether a given http.request should
+// be traced. A Filter must return true if the request should be traced.
+type Filter func(*http.Request) bool
+
+// SpanNameFormatter is used to set span name by http.request.
+type SpanNameFormatter func(r *http.Request) string
+
+// Option specifies instrumentation configuration options.
+type Option interface {
+	apply(*option)
+}
+
+type optionFunc func(*option)
+
+func (o optionFunc) apply(c *option) {
+	o(c)
+}
+
+// WithPropagators specifies propagators to use for extracting
+// information from the HTTP requests. If none are specified, global
+// ones will be used.
+func WithPropagators(propagators propagation.TextMapPropagator) Option {
+	return optionFunc(func(cfg *option) {
+		if propagators != nil {
+			cfg.Propagators = propagators
+		}
+	})
+}
+
+// WithTracerProvider specifies a tracer provider to use for creating a tracer.
+// If none is specified, the global provider is used.
+func WithTracerProvider(provider oteltrace.TracerProvider) Option {
+	return optionFunc(func(cfg *option) {
+		if provider != nil {
+			cfg.TracerProvider = provider
+		}
+	})
+}
+
+// WithFilter adds a filter to the list of filters used by the handler.
+// If any filter indicates to exclude a request then the request will not be
+// traced. All filters must allow a request to be traced for a Span to be created.
+// If no filters are provided then all requests are traced.
+// Filters will be invoked for each processed request, it is advised to make them
+// simple and fast.
+func WithFilter(f ...Filter) Option {
+	return optionFunc(func(c *option) {
+		c.Filters = append(c.Filters, f...)
+	})
+}
+
+// WithSpanNameFormatter takes a function that will be called on every
+// request and the returned string will become the Span Name.
+func WithSpanNameFormatter(f func(r *http.Request) string) Option {
+	return optionFunc(func(c *option) {
+		c.SpanNameFormatter = f
+	})
+}

--- a/bcs-common/pkg/otel/trace/gin/version.go
+++ b/bcs-common/pkg/otel/trace/gin/version.go
@@ -1,0 +1,25 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package gin
+
+// Version is the current release version of the gin instrumentation.
+func Version() string {
+	return "0.37.0"
+	// This string is updated by the pre_release.sh script during release
+}
+
+// SemVersion is the semantic version to be supplied to tracer/meter creation.
+func SemVersion() string {
+	return "semver:" + Version()
+}

--- a/bcs-common/pkg/otel/trace/micro/wrapper.go
+++ b/bcs-common/pkg/otel/trace/micro/wrapper.go
@@ -1,0 +1,95 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package micro
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"go-micro.dev/v4/metadata"
+	"go-micro.dev/v4/server"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	grpc_codes "google.golang.org/grpc/codes"
+
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/otel/trace/constants"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/otel/trace/utils"
+)
+
+func NewTracingWrapper() server.HandlerWrapper {
+	return func(fn server.HandlerFunc) server.HandlerFunc {
+		return func(ctx context.Context, req server.Request, rsp interface{}) (err error) {
+			// 开始时间
+			startTime := time.Now()
+			md, ok := metadata.FromContext(ctx)
+			if !ok {
+				return errors.New("failed to get micro's metadata")
+			}
+
+			// 获取或生成 request id 注入到 context
+			requestID := utils.GetOrCreateReqID(md)
+			ctx = context.WithValue(ctx, constants.RequestIDKey, requestID)
+			ctx = utils.ContextWithRequestID(ctx, requestID)
+
+			name := fmt.Sprintf("%s.%s", req.Service(), req.Endpoint())
+
+			tracer := otel.Tracer(req.Service())
+			commonAttrs := []attribute.KeyValue{
+				attribute.String("component", "gRPC"),
+				attribute.String("method", req.Method()),
+				attribute.String("url", req.Endpoint()),
+			}
+			ctx, span := tracer.Start(ctx, name, trace.WithSpanKind(trace.SpanKindServer),
+				trace.WithAttributes(commonAttrs...))
+			defer span.End()
+
+			reqData, _ := json.Marshal(req.Body())
+
+			err = fn(ctx, req, rsp)
+
+			rspData, _ := json.Marshal(rsp)
+			elapsedTime := time.Now().Sub(startTime)
+
+			reqBody := string(reqData)
+			if len(reqBody) > 1024 {
+				reqBody = fmt.Sprintf("%s...(Total %s)", reqBody[:1024], humanize.Bytes(uint64(len(reqBody))))
+			}
+
+			respBody := string(rspData)
+			if len(respBody) > 1024 {
+				respBody = fmt.Sprintf("%s...(Total %s)", respBody[:1024], humanize.Bytes(uint64(len(respBody))))
+			}
+
+			// 设置额外标签
+			span.SetAttributes(attribute.Key("req").String(reqBody))
+			span.SetAttributes(attribute.Key("elapsed_ime").String(elapsedTime.String()))
+			span.SetAttributes(attribute.Key("rsp").String(respBody))
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+				span.SetAttributes(constants.GRPCStatusCodeKey.Int(int(codes.Error)))
+			} else {
+				span.SetAttributes(constants.GRPCStatusCodeKey.Int(int(grpc_codes.OK)))
+			}
+
+			return err
+		}
+	}
+}

--- a/bcs-common/pkg/otel/trace/utils/context.go
+++ b/bcs-common/pkg/otel/trace/utils/context.go
@@ -1,0 +1,45 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"go-micro.dev/v4/metadata"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ContextWithRequestID returns a copy of parent with requestID set as the current Span.
+func ContextWithRequestID(parent context.Context, requestID string) context.Context {
+	requestID = strings.Replace(requestID, "-", "", -1)
+	tid, _ := trace.TraceIDFromHex(requestID)
+	sid, _ := trace.SpanIDFromHex(requestID)
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	return trace.ContextWithSpanContext(parent, sc)
+}
+
+// GetOrCreateReqID 尝试读取 X-Request-Id，若不存在则随机生成
+func GetOrCreateReqID(md metadata.Metadata) string {
+	if reqID, ok := md.Get("x-request-id"); ok {
+		return reqID
+	}
+	return uuid.New().String()
+}

--- a/bcs-common/pkg/otel/trace/utils/utils.go
+++ b/bcs-common/pkg/otel/trace/utils/utils.go
@@ -31,9 +31,12 @@ func Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
 // If none is registered then an instance of NoopTracerProvider is returned.
 //
 // Use the trace provider to create a named tracer. E.g.
-//     tracer := utils.GetTracerProvider().Tracer("example.com/foo")
+//
+//	tracer := utils.GetTracerProvider().Tracer("example.com/foo")
+//
 // or
-//     tracer := utils.Tracer("example.com/foo")
+//
+//	tracer := utils.Tracer("example.com/foo")
 func GetTracerProvider() trace.TracerProvider {
 	return otel.GetTracerProvider()
 }
@@ -46,10 +49,10 @@ func SetTracerProvider(tp trace.TracerProvider) {
 // NewTracerProvider returns a new and configured TracerProvider.
 //
 // By default the returned TracerProvider is configured with:
-//  - a ParentBased(AlwaysSample) Sampler
-//  - a random number IDGenerator
-//  - the resource.Default() Resource
-//  - the default SpanLimits.
+//   - a ParentBased(AlwaysSample) Sampler
+//   - a random number IDGenerator
+//   - the resource.Default() Resource
+//   - the default SpanLimits.
 //
 // The passed opts are used to override these default values and configure the
 // returned TracerProvider appropriately.


### PR DESCRIPTION
- bcs-common新增gin tracing中间件
- 打印请求和响应数据，支持路由过滤