### PR TITLE
fix：修复db连接错误（invalid connection）

### DIFF
--- a/bcs-services/bcs-bscp/pkg/cc/types.go
+++ b/bcs-services/bcs-bscp/pkg/cc/types.go
@@ -475,7 +475,7 @@ func (ds *Database) trySetDefault() {
 	}
 
 	if ds.MaxIdleTimeoutMin == 0 {
-		ds.MaxIdleTimeoutMin = 60
+		ds.MaxIdleTimeoutMin = 3
 	}
 }
 


### PR DESCRIPTION
db连接的最大生存时间（SetConnMaxLifetime）参数修改
复现方式：
初始化mysql后，sleep 30s , 之后执行select 操作，sleep过程中，重启mysql
```
import (
	"database/sql"
	"fmt"

	"time"
)

var (
	dsn string = "root:123456@tcp(127.0.0.1:3306)/db"
	db  *sql.DB
	err error
)


type user struct {
	Id   int
	Name string
	Age  int
}

// init 初始化
func init() {
	db, err = sql.Open("mysql", dsn)
	if err != nil {
		fmt.Println(err, "fail to open sql")
	}
	
	err = db.Ping()
	if err != nil {
		fmt.Println(err, "fail to ping database")
	}
	
	fmt.Println("connect mysql success!")
	
}


func main() {
	defer db.Close()
	fmt.Println("开始睡眠...")
	time.Sleep(time.Second * 30)
	fmt.Println("睡眠结束...")
	//查库
	sql := "SELECT * FROM users"
	rows, err := db.Query(sql)
	fmt.Println(err, "fail to query")
	for rows.Next() {
		u := user{}
		err := rows.Scan(&u.Id, &u.Name, &u.Age)
		if err != nil {
			fmt.Printf("查询失败 :%+v\n", err)
			return
		}
		fmt.Printf("批量成功 :%+v\n", u)
	}
}


```

解决方式：
设置连接的最大生存时间（SetConnMaxLifetime）；
由于某些插件限制的最大连接时间为 5 分钟， go-sql-driver 建议的连接时间在5分钟内
