### PR TITLE
 bk-bcs #2409 部署脚本集成离线部署方案#2409

### DIFF
--- a/bcs-ops/env/offline-manifest.yaml
+++ b/bcs-ops/env/offline-manifest.yaml
@@ -1,0 +1,98 @@
+bcs-ops:
+  - version: "1.20.15"
+    bin-tools:
+      k8s: "1.20.15"
+      cni-plugins: "1.3.0"
+      crictl: "1.26.0"
+      containerd: "1.6.21"
+      runc: "1.1.8"
+      docker: "19.03.9"
+
+    images:
+      - hub.bktencent.com/registry.k8s.io/kube-apiserver:v1.20.15
+      - hub.bktencent.com/registry.k8s.io/kube-controller-manager:v1.20.15
+      - hub.bktencent.com/registry.k8s.io/kube-scheduler:v1.20.15
+      - hub.bktencent.com/registry.k8s.io/kube-proxy:v1.20.15
+      - hub.bktencent.com/registry.k8s.io/pause:3.2
+      - hub.bktencent.com/registry.k8s.io/etcd:3.4.13-0
+      - hub.bktencent.com/registry.k8s.io/coredns:1.7.0
+      - hub.bktencent.com/library/hello-world:latest
+      - hub.bktencent.com/flannel/flannel-cni-plugin:v1.1.2
+      - hub.bktencent.com/flannel/flannel:v0.22.0
+      - hub.bktencent.com/k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+      - hub.bktencent.com/registry.k8s.io/metrics-server/metrics-server:v0.6.3
+      - hub.bktencent.com/alpine/helm:3.7.2
+      - hub.bktencent.com/registry.k8s.io/ingress-nginx/controller:v1.3.1
+      - hub.bktencent.com/registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0
+
+    charts:
+      - provisioner-2.4.0.tgz
+      - ingress-nginx-4.2.5.tgz
+
+    rpm:
+      - bash-completion-2.1-8.el7.noarch.rpm
+
+  - version: "1.23.17"
+    bin-tools:
+      k8s: "1.23.17"
+      cni-plugins: "1.3.0"
+      crictl: "1.26.0"
+      containerd: "1.6.21"
+      runc: "1.1.8"
+      docker: "19.03.9"
+
+    images:
+      - hub.bktencent.com/registry.k8s.io/kube-apiserver:v1.23.17
+      - hub.bktencent.com/registry.k8s.io/kube-controller-manager:v1.23.17
+      - hub.bktencent.com/registry.k8s.io/kube-scheduler:v1.23.17
+      - hub.bktencent.com/registry.k8s.io/kube-proxy:v1.23.17
+      - hub.bktencent.com/registry.k8s.io/pause:3.6
+      - hub.bktencent.com/registry.k8s.io/etcd:3.5.6-0
+      - hub.bktencent.com/registry.k8s.io/coredns:v1.8.6
+      - hub.bktencent.com/library/hello-world:latest
+      - hub.bktencent.com/flannel/flannel-cni-plugin:v1.1.2
+      - hub.bktencent.com/flannel/flannel:v0.22.0
+      - hub.bktencent.com/k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+      - hub.bktencent.com/registry.k8s.io/metrics-server/metrics-server:v0.6.3
+      - hub.bktencent.com/alpine/helm:3.7.2
+      - hub.bktencent.com/registry.k8s.io/ingress-nginx/controller:v1.3.1
+      - hub.bktencent.com/registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0
+
+    charts:
+      - provisioner-2.4.0.tgz
+      - ingress-nginx-4.2.5.tgz
+
+    rpm:
+      - bash-completion-2.1-8.el7.noarch.rpm
+
+  - version: "1.24.15"
+    bin-tools:
+      k8s: "1.24.15"
+      cni-plugins: "1.3.0"
+      crictl: "1.26.0"
+      containerd: "1.6.21"
+      runc: "1.1.8"
+
+    images:
+      - hub.bktencent.com/registry.k8s.io/kube-apiserver:v1.24.15
+      - hub.bktencent.com/registry.k8s.io/kube-controller-manager:v1.24.15
+      - hub.bktencent.com/registry.k8s.io/kube-scheduler:v1.24.15
+      - hub.bktencent.com/registry.k8s.io/kube-proxy:v1.24.15
+      - hub.bktencent.com/registry.k8s.io/pause:3.7
+      - hub.bktencent.com/registry.k8s.io/etcd:3.5.6-0
+      - hub.bktencent.com/registry.k8s.io/coredns:v1.8.6
+      - hub.bktencent.com/library/hello-world:latest
+      - hub.bktencent.com/flannel/flannel-cni-plugin:v1.1.2
+      - hub.bktencent.com/flannel/flannel:v0.22.0
+      - hub.bktencent.com/k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+      - hub.bktencent.com/registry.k8s.io/metrics-server/metrics-server:v0.6.3
+      - hub.bktencent.com/alpine/helm:3.7.2
+      - hub.bktencent.com/registry.k8s.io/ingress-nginx/controller:v1.3.1
+      - hub.bktencent.com/registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.3.0
+
+    charts:
+      - provisioner-2.4.0.tgz
+      - ingress-nginx-4.2.5.tgz
+
+    rpm:
+      - bash-completion-2.1-8.el7.noarch.rpm

--- a/bcs-ops/install_node.sh
+++ b/bcs-ops/install_node.sh
@@ -79,7 +79,7 @@ init_bap_rule() {
         utils::log "ERROR" "containerd client: ctr is not found"
       fi
       if ctr i pull --hosts-dir "/etc/containerd/certs.d" "${bap_image}"; then
-        if ! ctr run --rm --mount type=bind,src="${PROXY_TOOL_PATH}",dst=/tmp,options=rbind:rw "${bap_image}" \
+        if ! ctr -n k8s.io run --rm --mount type=bind,src="${PROXY_TOOL_PATH}",dst=/tmp,options=rbind:rw "${bap_image}" \
           bap-copy."$(date +%s)" /bin/cp -f /data/bcs/bcs-apiserver-proxy/apiserver-proxy-tools /tmp/; then
           utils::log "ERROR" "containerd fail to run ${bap_image}"
         fi
@@ -106,7 +106,6 @@ safe_source "${ROOT_DIR}/functions/k8s.sh"
 
 "${ROOT_DIR}"/system/config_envfile.sh -c init
 "${ROOT_DIR}"/system/config_system.sh -c dns sysctl
-"${ROOT_DIR}"/system/config_iptables.sh add
 "${ROOT_DIR}"/k8s/install_cri.sh
 "${ROOT_DIR}"/k8s/install_k8s_tools
 "${ROOT_DIR}"/k8s/render_kubeadm

--- a/bcs-ops/k8s/install_containerd
+++ b/bcs-ops/k8s/install_containerd
@@ -68,6 +68,26 @@ _yum_containerd() {
   return 0
 }
 
+_offline_containerd() {
+  local bin_path tar_name
+  bin_path=${ROOT_DIR}/version-${VERSION}/bin-tools/
+
+  tar_name=$(find "$bin_path" -iname "containerd-*.tgz" -type f | head -1)
+  if [[ -z ${tar_name} ]]; then
+    utils::log "FATAL" "can't find docker installation package in ${bin_path}"
+  else
+    tar xvzf "${tar_name}" -C /usr/bin/ --strip-components=1 bin/
+    tar xvzf "${tar_name}" -C /etc/systemd/system/ --strip-components=1 systemd/
+  fi
+
+  tar_name=$(find "$bin_path" -iname "runc-*.tgz" -type f | head -1)
+  if [[ -z ${tar_name} ]]; then
+    utils::log "FATAL" "can't find docker installation package in ${bin_path}"
+  else
+    tar xvzf "${tar_name}" -C /usr/bin/ --strip-components=1 bin/
+  fi
+}
+
 # ToDo: config separte
 render_containerd() {
   trap "utils::on_ERR;" ERR
@@ -145,8 +165,7 @@ main() {
     utils::log "WARN" "containerd installed, $(ctr -v)"
   else
     if [[ -n ${BCS_OFFLINE:-} ]]; then
-      # ToDo offline install containerd
-      true
+	  _offline_containerd
     else
       _yum_containerd
     fi
@@ -162,6 +181,11 @@ main() {
     utils::log "ERROR" "Did containerd get installed?"
   fi
 
+  if [[ -n ${BCS_OFFLINE:-} ]]; then
+    find "${ROOT_DIR}"/version-"${VERSION}"/images -name '*.tar' -type f -print0 \
+      | xargs -0 -I {} ctr -n k8s.io image import {}
+  fi
+
   # function testing
   local test_img_url
   test_img_url=${BK_PUBLIC_REPO:-"docker.io"}/library/hello-world:latest
@@ -173,7 +197,7 @@ main() {
   fi
 
   if ! (ctr i pull --hosts-dir "/etc/containerd/certs.d" "$test_img_url" \
-    && ctr run --rm "$test_img_url" hello-world."$(date +%s)"); then
+    && ctr -n k8s.io run --rm "$test_img_url" hello-world."$(date +%s)"); then
     utils::log "ERROR" "Could not get containerd to run ${test_img_url}"
   fi
   return 0

--- a/bcs-ops/k8s/install_docker
+++ b/bcs-ops/k8s/install_docker
@@ -74,6 +74,19 @@ _yum_docker() {
   return 0
 }
 
+_offline_docker() {
+  local bin_path tar_name
+  bin_path=${ROOT_DIR}/version-${VERSION}/bin-tools/
+  tar_name=$(find "$bin_path" -iname "docker-*.tgz" -type f | head -1)
+
+  if [[ -z ${tar_name} ]]; then
+    utils::log "FATAL" "can't find docker installation package in ${bin_path}"
+  else
+    tar xvzf "${tar_name}" -C /usr/bin/ --strip-components=1 bin/
+    tar xvzf "${tar_name}" -C /etc/systemd/system/ --strip-components=1 systemd/
+  fi
+}
+
 # ToDo: config separte
 render_docker() {
   trap "utils::on_ERR;" ERR
@@ -135,8 +148,7 @@ main() {
     utils::log "WARN" "docker installed, $(docker -v)"
   else
     if [[ -n ${BCS_OFFLINE:-} ]]; then
-      # ToDo offline install docker
-      true
+      _offline_docker
     else
       _yum_docker
     fi
@@ -150,6 +162,12 @@ main() {
   # install testing
   if ! docker --version; then
     utils::log "ERROR" "Did docker get installed?"
+  fi
+
+  # load image
+  if [[ -n ${BCS_OFFLINE:-} ]]; then
+    find "${ROOT_DIR}"/version-"${VERSION}"/images -name '*.tar' -type f -print0 \
+      | xargs -0 -I {} docker load -i {}
   fi
 
   # function testing

--- a/bcs-ops/k8s/install_helm
+++ b/bcs-ops/k8s/install_helm
@@ -57,7 +57,7 @@ if ! helm version --short /dev/null | grep -qoE "^v${HELM_VER}"; then
         utils::log "ERROR" "containerd client: ctr is not found"
       fi
       if ctr i pull --hosts-dir "/etc/containerd/certs.d" "${helm_image}"; then
-        if ! ctr run --rm --mount type=bind,src=/usr/bin,dst=/tmp,options=rbind:rw \
+        if ! ctr -n k8s.io run --rm --mount type=bind,src=/usr/bin,dst=/tmp,options=rbind:rw \
           "${helm_image}" helm-copy."$(date +%s)" /bin/cp -f /usr/bin/helm /tmp/; then
           utils::log "ERROR" "containerd fail to run ${helm_image}"
         fi

--- a/bcs-ops/k8s/install_k8s_tools
+++ b/bcs-ops/k8s/install_k8s_tools
@@ -60,17 +60,7 @@ safe_source() {
   fi
 }
 
-main() {
-  local source_file
-  source_files=("${ROOT_DIR}/functions/utils.sh" "${ROOT_DIR}/env/bcs.env")
-  for file in "${source_files[@]}"; do
-    safe_source "$file"
-  done
-
-  if [[ -n ${BCS_OFFLINE:-} ]]; then
-    true
-  fi
-
+_yum_k8s() {
   add_yum_repo
 
   local pkg_pat pkg_ver
@@ -80,6 +70,51 @@ main() {
   [[ -n $pkg_ver ]] \
     || utils::log "ERROR" "${K8S_VER:-} not found amongst yum list results"
   yum install -y "kubeadm-${pkg_ver}" "kubelet-${pkg_ver}" "kubectl-${pkg_ver}"
+}
+
+_offline_k8s() {
+  local bin_path tar_name
+  bin_path=${ROOT_DIR}/version-${VERSION}/bin-tools/
+
+  tar_name=$(find "$bin_path" -iname "k8s-*.tgz" -type f | head -1)
+  if [[ -z ${tar_name} ]]; then
+    utils::log "FATAL" "can't find docker installation package in ${bin_path}"
+  else
+    tar xvzf "${tar_name}" -C /usr/bin/ --strip-components=1 bin/
+    tar xvzf "${tar_name}" -C /etc/systemd/system/ --strip-components=1 systemd/
+	mkdir -pv /etc/systemd/system/kubelet.service.d/
+	tar xvzf "${tar_name}" -C /etc/systemd/system/kubelet.service.d/ \
+	  --strip-components=1 systemd/10-kubeadm.conf
+  fi
+
+  tar_name=$(find "$bin_path" -iname "crictl-*.tgz" -type f | head -1)
+  if [[ -z ${tar_name} ]]; then
+    utils::log "FATAL" "can't find docker installation package in ${bin_path}"
+  else
+    tar xvzf "${tar_name}" -C /usr/bin/ --strip-components=1 bin/
+  fi
+
+  tar_name=$(find "$bin_path" -iname "cni-plugins-*.tgz" -type f | head -1)
+  if [[ -z ${tar_name} ]]; then
+    utils::log "FATAL" "can't find docker installation package in ${bin_path}"
+  else
+    mkdir -pv /opt/cni/bin
+    tar xvzf "${tar_name}" -C /opt/cni/bin --strip-components=1 bin/
+  fi
+}
+
+main() {
+  local source_file
+  source_files=("${ROOT_DIR}/functions/utils.sh" "${ROOT_DIR}/env/bcs.env")
+  for file in "${source_files[@]}"; do
+    safe_source "$file"
+  done
+
+  if [[ -n ${BCS_OFFLINE:-} ]]; then
+    _offline_k8s
+  else
+    _yum_k8s
+  fi
 
   utils::log "INFO" "check kubeadm status"
   if kubeadm version -o short; then

--- a/bcs-ops/k8s/install_localpv
+++ b/bcs-ops/k8s/install_localpv
@@ -54,33 +54,43 @@ safe_source() {
 }
 
 install_localpv() {
-  local namespace="bk-system" mount_path="$1"
+  local namespace="bk-system"
   kubectl get ns "$namespace" || kubectl create ns $namespace
 
-  # ToDo helm chart offline install
   if [[ -n ${BCS_OFFLINE:-} ]]; then
-    true
+    chart_path="$(find "${ROOT_DIR}/version-${VERSION}/charts/" -iname "provisioner-*.tgz" -type f | head -1)"
+    if [[ -z $chart_path ]]; then
+      utils::log "FATAL" "can't find provisioner chart in ${ROOT_DIR}/version-${VERSION}/charts/"
+    fi
   else
     [[ -n ${BKREPO_URL:-} ]] || utils::log "FAIL" "missing bkrepo url ${BKREPO_URL}"
     if ! k8s::safe_add_helmrepo blueking "${BKREPO_URL}"; then
-      utils::log "WARNING" "something wrong with helm, skip install localpv"
+      utils::log "WARNING" "something wrong with helm, skip install provisioner"
       return 1
     fi
+    chart_path="blueking/provisioner"
+  fi
 
-    utils::log "INFO" "installing localpv"
-    cat <<EOF | helm upgrade --install provisioner blueking/provisioner -n $namespace --version ${VERSION} --debug -f - || utils::log "FATAL" "helm upgrade localpv failed"
+  local image
+  if [[ -n ${BK_PUBLIC_REPO:-} ]];then
+	image="${BK_PUBLIC_REPO}/k8s.gcr.io/sig-storage/local-volume-provisioner:${VERSION}"
+  else
+    image="registry.k8s.io/sig-storage/local-volume-provisioner:${VERSION}"
+  fi
+
+  utils::log "INFO" "installing localpv"
+  cat <<EOF | helm upgrade --install provisioner blueking/provisioner -n $namespace --version ${VERSION} --debug -f - || utils::log "FATAL" "helm upgrade localpv failed"
 daemonset:
-  image: ${BK_PUBLIC_REPO}/k8s.gcr.io/sig-storage/local-volume-provisioner:${VERSION}
+  image: ${image}
 classes:
 - name: local-storage
-  hostDir: $mount_path
+  hostDir: "${LOCALPV_DIR}"
   volumeMode: Filesystem
   storageClass:
     # create and set storage class as default
     isDefaultClass: true
-    reclaimPolicy: Delete
+    reclaimPolicy: "${LOCALPV_reclaimPolicy:-"Delete"}"
 EOF
-  fi
   kubectl -n $namespace get daemonset -l app.kubernetes.io/instance=localpv --output name \
     | xargs -I{} kubectl -n $namespace rollout status --timeout=600s {}
   utils::log "OK" "localpv installed"
@@ -92,6 +102,6 @@ main() {
   for file in "${source_files[@]}"; do
     safe_source "$file"
   done
-  install_localpv "$1"
+  install_localpv
 }
-main "${1:-/mnt/blueking}"
+main

--- a/bcs-ops/k8s/operate_completion
+++ b/bcs-ops/k8s/operate_completion
@@ -46,7 +46,11 @@ check_completion() {
     utils::log "INFO" "installing bash-completion"
     if [[ -n ${BCS_OFFLINE:-} ]]; then
       # ToDo helm image offline install
-      true
+      rpm_path="$(find "${ROOT_DIR}/version-${VERSION}/rpm/" -iname "bash-completion-*.rpm" -type f | head -1)"
+      if [[ -z $rpm_path ]]; then
+        utils::log "FATAL" "can't find bash-completion rpm in ${ROOT_DIR}/version-${VERSION}/rpm/"
+      fi
+      rpm -ivh "$rpm_path"
     else
       yum install -y bash-completion \
         || utils::log "FATAL" "fail to install bash-completion"

--- a/bcs-ops/system/config_envfile.sh
+++ b/bcs-ops/system/config_envfile.sh
@@ -52,10 +52,10 @@ init_env() {
   LAN_IP=${LAN_IP:-}
   LAN_IPv6=${LAN_IPv6:-}
   BCS_SYSCTL=${BCS_SYSCTL:=1}
-  if [[ ${K8S_IPv6_STATUS,,} != "singlestack" ]]; then
+  if [[ -z ${LAN_IP} ]] && [[ ${K8S_IPv6_STATUS,,} != "singlestack" ]]; then
     LAN_IP="$("${ROOT_DIR}"/system/get_lan_ip -4)"
   fi
-  if [[ ${K8S_IPv6_STATUS,,} != "disable" ]]; then
+  if [[ -z $LAN_IPv6 ]] && [[ ${K8S_IPv6_STATUS,,} != "disable" ]]; then
     LAN_IPv6="$("${ROOT_DIR}"/system/get_lan_ip -6)"
   fi
   BCS_OFFLINE=${BCS_OFFLINE:-}
@@ -96,6 +96,10 @@ init_env() {
 
   # csi
   K8S_CSI=${K8S_CSI:-"localpv"}
+  ## localpv
+  LOCALPV_DIR=${LOCALPV_DIR:-${BK_HOME}/localpv}
+  LOCALPV_COUNT=${LOCALPV_COUNT:-20}
+  LOCALPV_reclaimPolicy=${LOCALPV_reclaimPolicy:-"Delete"}
 
   # mirror
   ## yum_mirror

--- a/bcs-ops/system/config_system.sh
+++ b/bcs-ops/system/config_system.sh
@@ -198,8 +198,7 @@ close_swap() {
 }
 
 stop_firewalld() {
-    firewall_status=$(systemctl is-active firewalld)
-    if [[ $firewall_status == "active" ]]; then
+	if systemctl is-active firewalld; then
         utils::log "INFO" "Stop firewalld"
         systemctl stop firewalld
         systemctl disable firewalld

--- a/bcs-ops/system/mount_localpv
+++ b/bcs-ops/system/mount_localpv
@@ -41,16 +41,12 @@ for file in "${source_files[@]}"; do
   safe_source "$file"
 done
 
-LOCALPV_DIR=${LOCALPV_DIR:-${BK_HOME}/localpv}
-MOUNT_PATH=${1:-"/mnt/blueking"}
-COUNT=${2:-20}
-
-eval "install -dv ${MOUNT_PATH}/vol{01..$COUNT} $LOCALPV_DIR/vol{01..$COUNT}" \
+eval "install -dv  $LOCALPV_DIR/vol{01..$LOCALPV_COUNT}" \
   || utils::log "FATAL" "create mount dir failed"
 
-for i in $(seq -w 1 "$COUNT"); do
-  src_dir="${BK_HOME}/localpv/vol$i"
-  dst_dir="/mnt/blueking/vol$i"
+for i in $(seq -w 1 "$LOCALPV_COUNT"); do
+  src_dir="$LOCALPV_DIR/vol$i"
+  dst_dir="${src_dir}"
   if grep -w "$src_dir" /etc/fstab; then
     utils::log "WARN" "/etc/fstab: [$src_dir] already exists"
   else


### PR DESCRIPTION
feat: 支持离线安装 k8s \ docker \ containerd \[部署脚本集成离线部署方案#2409](https://github.com/TencentBlueKing/bk-bcs/issues/2409)
fix: master上架完成后，重新渲染一次env。
fix: 引入 localpv 相关的环境变量来控制
fix: ingress 和 localpv 镜像 registry 的渲染
fix: IP 环境变量可以外部传入

doc: 新增 iptables 策略和预置检查、离线安装、localpv相关说明。调整相关的结构 [OS初始化安全规则文档补充#2458](https://github.com/TencentBlueKing/bk-bcs/issues/2458)
doc: 增加 离线资源清单