### PR TITLE
bcs-ops 支持install_master/node脚本重入

### DIFF
--- a/bcs-ops/install_node.sh
+++ b/bcs-ops/install_node.sh
@@ -121,20 +121,21 @@ case "${K8S_CSI,,}" in
     ;;
 esac
 
-# pull image
-if [[ -n ${BCS_OFFLINE:-} ]]; then
-  # import local image
-  true
-fi
 kubeadm --config="${ROOT_DIR}/kubeadm-config" config images pull \
   || utils::log "FATAL" "fail to pull k8s image"
 
-kubeadm join --config="${ROOT_DIR}/kubeadm-config" -v 11
+if systemctl is-active kubelet.service -q; then
+  utils::log "WARN" "kubelet service is active now, skip kubeadm join"
+else
+  kubeadm join --config="${ROOT_DIR}/kubeadm-config" -v 11 \
+    || utils::log "FATAL" "${LAN_IP} failed to join cluster: ${K8S_CTRL_IP}"
+fi
+
 if [[ "${ENABLE_APISERVER_HA}" == "true" ]]; then
   if [[ "${APISERVER_HA_MODE}" == "bcs-apiserver-proxy" ]]; then
     init_bap_rule
   else
     "${ROOT_DIR}"/system/config_bcs_dns -u "${VIP}" k8s-api.bcs.local
-    systemctl restart kubelet.service
+    k8s::restart_kubelet
   fi
 fi

--- a/bcs-ops/system/config_envfile.sh
+++ b/bcs-ops/system/config_envfile.sh
@@ -263,6 +263,17 @@ BCS_CP_WORKER="${BCS_CP_WORKER}"
 
 # csi
 K8S_CSI="${K8S_CSI}"
+$(
+    case "${K8S_CSI,,}" in
+      "localpv")
+        cat <<CSI_EOF
+LOCALPV_DIR="${LOCALPV_DIR}"
+LOCALPV_COUNT="${LOCALPV_COUNT}"
+LOCALPV_reclaimPolicy="${LOCALPV_reclaimPolicy}"
+CSI_EOF
+        ;;
+    esac
+  )
 
 ## yum_mirror
 MIRROR_URL="${MIRROR_URL}"


### PR DESCRIPTION
fix: localpv 相关变量没有渲染到env文件中
feat: 支持install_master/node脚本重入（判断 kubelet 状态是否执行kubeadm init/join）