### PR TITLE
bcs-ops 离线部署文档#2589

### DIFF
--- a/bcs-ops/Makefile
+++ b/bcs-ops/Makefile
@@ -4,13 +4,11 @@ CURRENT_VERSION = release-$(VER)
 
 clean:
 	-rm ./bcs-ops-script-release-$(VER).tar.gz
-	-rm ./bcs-ops-offline-release-$(VER).tar.gz
 	-rm MD5SUMS
 
 build:clean
 	find . -not -path "*/.git/*" -a -not -path "*/bin/*" -a -not -path "*/image/*" -a -not -path "*/Makefile" -a -not -path "*/functions/*" -type f -print0 | xargs -0 chmod 555
 	find ./functions/ -not -path "*/.git/*" -a -not -path "*/bin/*" -a -not -path "*/image/*" -a -not -path "*/Makefile" -type f -print0 | xargs -0 chmod 444
 	tar -czvf bcs-ops-script-release-$(VER).tar.gz  --exclude=bin --exclude=image --exclude=Makefile --exclude=\..* --exclude=.*tar.gz ./*
-	tar -czvf bcs-ops-offline-release-$(VER).tar.gz  --exclude=Makefile --exclude=\..* --exclude=.*tar.gz ./*
 	md5sum bcs-ops-script-release-$(VER).tar.gz >> MD5SUMS
 	md5sum bcs-ops-offline-release-$(VER).tar.gz >> MD5SUMS

--- a/bcs-ops/install_master.sh
+++ b/bcs-ops/install_master.sh
@@ -55,9 +55,13 @@ safe_source "${ROOT_DIR}/functions/k8s.sh"
 safe_source "${ROOT_DIR}/env/bcs.env"
 
 # pull image
-kubeadm --config="${ROOT_DIR}/kubeadm-config" config images pull \
-  || utils::log "FATAL" "fail to pull k8s image"
+if [[ -z ${BCS_OFFLINE:-} ]]; then
+  kubeadm --config="${ROOT_DIR}/kubeadm-config" config images pull \
+    || utils::log "FATAL" "fail to pull k8s image"
+fi
 
+# wait to check kubelet start
+sleep 30
 if [[ -z ${MASTER_JOIN_CMD:-} ]]; then
   if systemctl is-active kubelet.service -q; then
     utils::log "WARN" "kubelet service is active now, skip kubeadm init"

--- a/bcs-ops/install_node.sh
+++ b/bcs-ops/install_node.sh
@@ -122,15 +122,20 @@ case "${K8S_CSI,,}" in
     ;;
 esac
 
-kubeadm --config="${ROOT_DIR}/kubeadm-config" config images pull \
-  || utils::log "FATAL" "fail to pull k8s image"
+if [[ -z ${BCS_OFFLINE:-} ]]; then
+  kubeadm --config="${ROOT_DIR}/kubeadm-config" config images pull \
+    || utils::log "FATAL" "fail to pull k8s image"
+fi
 
+# wait kubelet to start
+sleep 30
 if systemctl is-active kubelet.service -q; then
   utils::log "WARN" "kubelet service is active now, skip kubeadm join"
 else
   kubeadm join --config="${ROOT_DIR}/kubeadm-config" -v 11 \
     || utils::log "FATAL" "${LAN_IP} failed to join cluster: ${K8S_CTRL_IP}"
 fi
+
 
 if [[ "${ENABLE_APISERVER_HA}" == "true" ]]; then
   if [[ "${APISERVER_HA_MODE}" == "bcs-apiserver-proxy" ]]; then

--- a/bcs-ops/k8s/insecure_registry.sh
+++ b/bcs-ops/k8s/insecure_registry.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+set -euo pipefail
+
+# 通用脚本框架变量
+PROGRAM=$(basename "$0")
+
+# 定义需要设置为免证书信任的registry地址
+REGISTRIES=()
+TIMESTMP=$(date +%s)
+CRI_TYPE=""
+ACTION=""
+
+usage_and_exit() {
+    cat <<EOF
+	免证书信任的registry地址，docker 需要
+Usage:
+	$PROGRAM -c containerd -a docker.example.com docker.example2.com:8080
+	$PROGRAM -c docker -d docker.example.com docker.example2.com:8080
+    $PROGRAM [ -h --help -?  show usage ]
+			 [ -a, --add add insecure registry]
+			 [ -d, --del remove insecure registry]
+             [ -c, --cri-type  support docker\containerd]
+EOF
+    exit "$1"
+}
+
+version() {
+    echo "$PROGRAM version $VERSION"
+}
+
+while (($# > 0)); do
+    case "$1" in
+        -a | --add)
+            shift
+            if [[ -z $ACTION ]]; then
+                ACTION="add"
+            else
+                echo "ACTION already define: ${ACTION}"
+                usage_and_exit 1
+            fi
+            while (($# > 0)) && [[ "$1" != -* ]]; do
+                REGISTRIES+=("$1")
+                shift
+            done
+            continue
+            ;;
+        -d | --del)
+            shift
+            if [[ -z $ACTION ]]; then
+                ACTION="del"
+            else
+                echo "ACTION already define: ${ACTION}"
+                usage_and_exit 1
+            fi
+            while (($# > 0)) && [[ "$1" != -* ]]; do
+                REGISTRIES+=("$1")
+                shift
+            done
+            continue
+            ;;
+        -c | --cri-type)
+            shift
+            CRI_TYPE=$1
+            ;;
+        --help | -h | '-?')
+            usage_and_exit 0
+            ;;
+        -*)
+            error "不可识别的参数: $1"
+            ;;
+        *)
+            break
+            ;;
+    esac
+    (($# > 0)) && shift
+done
+
+add_docker() {
+    # 获取docker配置文件路径
+    DOCKER_CONFIG_PATH="/etc/docker/daemon.json"
+
+    # 文件不存在，则需要创建
+    if [[ ! -f "$DOCKER_CONFIG_PATH" ]]; then
+        echo "{}" >"$DOCKER_CONFIG_PATH"
+    fi
+
+    cp $DOCKER_CONFIG_PATH $DOCKER_CONFIG_PATH.registry.tmp
+
+    registries=$(printf '"%s",' "${REGISTRIES[@]}")
+    registries="[${registries%,}]"
+
+    jq --arg k 'insecure-registries' --argjson v "$registries" '.[$k] as $insecure_registries | if $insecure_registries then reduce $v[] as $r (.; if $insecure_registries | index($r) == null then .[$k] += [$r] else . end) else .[$k] = $v end' $DOCKER_CONFIG_PATH >/tmp/docker_daemon-"${TIMESTMP}".tmp
+
+    cp "$DOCKER_CONFIG_PATH" "$DOCKER_CONFIG_PATH.${TIMESTMP}.bak"
+    mv /tmp/docker_daemon-"${TIMESTMP}".tmp "$DOCKER_CONFIG_PATH"
+    cat "$DOCKER_CONFIG_PATH"
+
+    # 重启docker服务
+    systemctl reload docker
+}
+
+del_docker() {
+    DOCKER_CONFIG_PATH="/etc/docker/daemon.json"
+
+    if [[ ! -f "$DOCKER_CONFIG_PATH" ]]; then
+        echo "{}" >"$DOCKER_CONFIG_PATH"
+        cat $DOCKER_CONFIG_PATH
+        return 0
+    fi
+
+    registries=$(printf '"%s",' "${REGISTRIES[@]}")
+    registries="[${registries%,}]"
+
+    jq --arg k 'insecure-registries' --argjson v "$registries" '.[$k] as $insecure_registries | if $insecure_registries then reduce $v[] as $r (.; if $insecure_registries | index($r) != null then .[$k] -= [$r] else . end) else .[$k] = $v end' $DOCKER_CONFIG_PATH >/tmp/docker_daemon-"${TIMESTMP}".tmp
+
+    cp "$DOCKER_CONFIG_PATH" "$DOCKER_CONFIG_PATH.$TIMESTMP.bak"
+    mv /tmp/docker_daemon-"${TIMESTMP}".tmp "$DOCKER_CONFIG_PATH"
+    cat "$DOCKER_CONFIG_PATH"
+
+    systemctl reload docker
+}
+
+add_containerd() {
+    local registry
+    for registry in "${REGISTRIES[@]}"; do
+        CONTAINERD_HOST_DIR="/etc/containerd/certs.d/${registry}"
+        mkdir -p "$CONTAINERD_HOST_DIR"
+        if [[ -f $CONTAINERD_HOST_DIR/hosts.toml ]]; then
+            cp "$CONTAINERD_HOST_DIR/hosts.toml" "$CONTAINERD_HOST_DIR/hosts.toml.${TIMESTMP}.bak"
+        fi
+        cat <<EOF >"$CONTAINERD_HOST_DIR/hosts.toml"
+[host."https://$registry"]
+  capabilities = ["pull", "resolve", "push"]
+  skip_verify = true
+EOF
+    done
+}
+
+del_containerd() {
+    local registry
+    for registry in "${REGISTRIES[@]}"; do
+        CONTAINERD_HOST_DIR="/etc/containerd/certs.d/${registry}"
+        if [[ -f $CONTAINERD_HOST_DIR/host.toml ]]; then
+            if grep -q "skip_verify = true" "$CONTAINERD_HOST_DIR"/host.toml; then
+                cp "$CONTAINERD_HOST_DIR/hosts.toml" "$CONTAINERD_HOST_DIR/hosts.toml.${TIMESTMP}.bak"
+                sed -i '/skip_verify = true/d' "$CONTAINERD_HOST_DIR"/host.toml
+            fi
+        fi
+    done
+}
+
+"${ACTION}_${CRI_TYPE}"

--- a/bcs-ops/k8s/install_containerd
+++ b/bcs-ops/k8s/install_containerd
@@ -68,9 +68,37 @@ _yum_containerd() {
   return 0
 }
 
+_curl_containerd() {
+  local bin_path name ver file url
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
+  mkdir -p "$bin_path"
+
+  name="containerd"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.tgz"
+  url=${REPO_URL}/${file}
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
+  else
+    utils::log "ERROR" "fail to download ${url}"
+  fi
+
+  name="runc"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.tgz"
+  url="${REPO_URL}/${file}"
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
+  else
+    utils::log "ERROR" "fail to download ${url}"
+  fi
+
+  _offline_containerd
+}
+
 _offline_containerd() {
   local bin_path tar_name
-  bin_path=${ROOT_DIR}/version-${VERSION}/bin-tools/
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
 
   tar_name=$(find "$bin_path" -iname "containerd-*.tgz" -type f | head -1)
   if [[ -z ${tar_name} ]]; then
@@ -165,9 +193,19 @@ main() {
     utils::log "WARN" "containerd installed, $(ctr -v)"
   else
     if [[ -n ${BCS_OFFLINE:-} ]]; then
-	  _offline_containerd
+      _offline_containerd
     else
-      _yum_containerd
+      case ${INSTALL_METHOD} in
+        "yum")
+          _yum_containerd
+          ;;
+        "curl")
+          _curl_containerd
+          ;;
+        *)
+          utils::log "ERROR" "unkown ${INSTALL_METHOD} to exec download containerd"
+          ;;
+      esac
     fi
   fi
 
@@ -181,6 +219,11 @@ main() {
     utils::log "ERROR" "Did containerd get installed?"
   fi
 
+  # add insecure_registry
+  if [[ -n ${INSECURE_REGISTRY:-} ]]; then
+    "${ROOT_DIR}"/k8s/insecure_registry.sh -c containerd -a "${INSECURE_REGISTRY}"
+  fi
+
   if [[ -n ${BCS_OFFLINE:-} ]]; then
     find "${ROOT_DIR}"/version-"${VERSION}"/images -name '*.tar' -type f -print0 \
       | xargs -0 -I {} ctr -n k8s.io image import {}
@@ -190,7 +233,6 @@ main() {
   local test_img_url
   test_img_url=${BK_PUBLIC_REPO:-"docker.io"}/library/hello-world:latest
   utils::log "DEBUG" "hello-world: ${test_img_url}"
-
 
   if ! (ctr -n k8s.io i pull --hosts-dir "/etc/containerd/certs.d" "$test_img_url" \
     && ctr -n k8s.io run --rm "$test_img_url" hello-world."$(date +%s)"); then

--- a/bcs-ops/k8s/install_docker
+++ b/bcs-ops/k8s/install_docker
@@ -74,9 +74,27 @@ _yum_docker() {
   return 0
 }
 
+_curl_docker() {
+  local bin_path name ver file url
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
+  mkdir -p "$bin_path"
+
+  name="docker"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.tgz"
+  url=${REPO_URL}/${file}
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
+  else
+    utils::log "ERROR" "fail to download ${url}"
+  fi
+
+  _offline_docker
+}
+
 _offline_docker() {
   local bin_path tar_name
-  bin_path=${ROOT_DIR}/version-${VERSION}/bin-tools/
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
   tar_name=$(find "$bin_path" -iname "docker-*.tgz" -type f | head -1)
 
   if [[ -z ${tar_name} ]]; then
@@ -84,6 +102,14 @@ _offline_docker() {
   else
     tar xvzf "${tar_name}" -C /usr/bin/ --strip-components=1 bin/
     tar xvzf "${tar_name}" -C /etc/systemd/system/ --strip-components=1 systemd/
+  fi
+
+  # docker.sock need docker group
+  if getent group docker >/dev/null 2>&1; then
+    utils::log "INFO" "docker group existed"
+  else
+    utils::log "INFO" "creating docker group"
+    groupadd docker
   fi
 }
 
@@ -150,7 +176,17 @@ main() {
     if [[ -n ${BCS_OFFLINE:-} ]]; then
       _offline_docker
     else
-      _yum_docker
+      case ${INSTALL_METHOD} in
+        "yum")
+          _yum_docker
+          ;;
+        "curl")
+          _curl_docker
+          ;;
+        *)
+          utils::log "ERROR" "unkown ${INSTALL_METHOD} to exec download docker"
+          ;;
+      esac
     fi
   fi
 
@@ -164,7 +200,12 @@ main() {
     utils::log "ERROR" "Did docker get installed?"
   fi
 
-  # load image
+  # add insecure_registry
+  if [[ -n ${INSECURE_REGISTRY:-} ]]; then
+    "${ROOT_DIR}"/k8s/insecure_registry.sh -c docker -a "${INSECURE_REGISTRY}"
+  fi
+
+  # bcs_offline load image
   if [[ -n ${BCS_OFFLINE:-} ]]; then
     find "${ROOT_DIR}"/version-"${VERSION}"/images -name '*.tar' -type f -print0 \
       | xargs -0 -I {} docker load -i {}
@@ -174,11 +215,6 @@ main() {
   local test_img_url
   test_img_url=${BK_PUBLIC_REPO:-"docker.io"}/library/hello-world:latest
   utils::log "DEBUG" "hello-world: ${test_img_url}"
-
-  if [[ -n ${BCS_OFFLINE:-} ]]; then
-    # ToDo hello world image offline install
-    true
-  fi
 
   if ! docker run --rm "${test_img_url}"; then
     utils::log "ERROR" "Count not get docker to run ${test_img_url}"

--- a/bcs-ops/k8s/install_k8s_tools
+++ b/bcs-ops/k8s/install_k8s_tools
@@ -72,9 +72,47 @@ _yum_k8s() {
   yum install -y "kubeadm-${pkg_ver}" "kubelet-${pkg_ver}" "kubectl-${pkg_ver}"
 }
 
+_curl_k8s() {
+  local bin_path name ver file url
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
+  mkdir -p "$bin_path"
+
+  name="k8s"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.tgz"
+  url=${REPO_URL:-}/${file}
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
+  else
+    utils::log "ERROR" "fail to download ${url}"
+  fi
+
+  name="crictl"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.tgz"
+  url="${REPO_URL}/${file}"
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
+  else
+    utils::log "ERROR" "fail to download ${url}"
+  fi
+
+  name="cni-plugins"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.tgz"
+  url="${REPO_URL}/${file}"
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
+  else
+    utils::log "ERROR" "fail to download ${url}"
+  fi
+
+  _offline_k8s
+}
+
 _offline_k8s() {
   local bin_path tar_name
-  bin_path=${ROOT_DIR}/version-${VERSION}/bin-tools/
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
 
   tar_name=$(find "$bin_path" -iname "k8s-*.tgz" -type f | head -1)
   if [[ -z ${tar_name} ]]; then
@@ -82,9 +120,9 @@ _offline_k8s() {
   else
     tar xvzf "${tar_name}" -C /usr/bin/ --strip-components=1 bin/
     tar xvzf "${tar_name}" -C /etc/systemd/system/ --strip-components=1 systemd/
-	mkdir -pv /etc/systemd/system/kubelet.service.d/
-	tar xvzf "${tar_name}" -C /etc/systemd/system/kubelet.service.d/ \
-	  --strip-components=1 systemd/10-kubeadm.conf
+    mkdir -pv /etc/systemd/system/kubelet.service.d/
+    tar xvzf "${tar_name}" -C /etc/systemd/system/kubelet.service.d/ \
+      --strip-components=1 systemd/10-kubeadm.conf
   fi
 
   tar_name=$(find "$bin_path" -iname "crictl-*.tgz" -type f | head -1)
@@ -113,7 +151,17 @@ main() {
   if [[ -n ${BCS_OFFLINE:-} ]]; then
     _offline_k8s
   else
-    _yum_k8s
+    case ${INSTALL_METHOD} in
+      "yum")
+        _yum_k8s
+        ;;
+      "curl")
+        _curl_k8s
+        ;;
+      *)
+        utils::log "ERROR" "unkown ${INSTALL_METHOD} to exec download k8s tools"
+        ;;
+    esac
   fi
 
   utils::log "INFO" "check kubeadm status"

--- a/bcs-ops/k8s/install_localpv
+++ b/bcs-ops/k8s/install_localpv
@@ -58,9 +58,9 @@ install_localpv() {
   kubectl get ns "$namespace" || kubectl create ns $namespace
 
   if [[ -n ${BCS_OFFLINE:-} ]]; then
-    chart_path="$(find "${ROOT_DIR}/version-${VERSION}/charts/" -iname "provisioner-*.tgz" -type f | head -1)"
+    chart_path="$(find "${ROOT_DIR}/version-${K8S_VER}/charts/" -iname "provisioner-*.tgz" -type f | head -1)"
     if [[ -z $chart_path ]]; then
-      utils::log "FATAL" "can't find provisioner chart in ${ROOT_DIR}/version-${VERSION}/charts/"
+      utils::log "FATAL" "can't find provisioner chart in ${ROOT_DIR}/version-${K8S_VER}/charts/"
     fi
   else
     [[ -n ${BKREPO_URL:-} ]] || utils::log "FAIL" "missing bkrepo url ${BKREPO_URL}"
@@ -72,8 +72,8 @@ install_localpv() {
   fi
 
   local image
-  if [[ -n ${BK_PUBLIC_REPO:-} ]];then
-	image="${BK_PUBLIC_REPO}/k8s.gcr.io/sig-storage/local-volume-provisioner:${VERSION}"
+  if [[ -n ${BK_PUBLIC_REPO:-} ]]; then
+    image="${BK_PUBLIC_REPO}/k8s.gcr.io/sig-storage/local-volume-provisioner:${VERSION}"
   else
     image="registry.k8s.io/sig-storage/local-volume-provisioner:${VERSION}"
   fi

--- a/bcs-ops/k8s/install_nginx_ingress.sh
+++ b/bcs-ops/k8s/install_nginx_ingress.sh
@@ -51,9 +51,9 @@ install_nginx_ingress() {
   local namespace=$NAMESPACE
   local chart_path
   if [[ -n ${BCS_OFFLINE:-} ]]; then
-    chart_path="$(find "${ROOT_DIR}/version-${VERSION}/charts/" -iname "ingress-nginx-*.tgz" -type f | head -1)"
+    chart_path="$(find "${ROOT_DIR}/version-${K8S_VER}/charts/" -iname "ingress-nginx-*.tgz" -type f | head -1)"
     if [[ -z $chart_path ]]; then
-      utils::log "FATAL" "can't find ingress-nginx chart in ${ROOT_DIR}/version-${VERSION}/charts/"
+      utils::log "FATAL" "can't find ingress-nginx chart in ${ROOT_DIR}/version-${K8S_VER}/charts/"
     fi
   else
     [[ -n ${BKREPO_URL:-} ]] || utils::log "FAIL" "missing bkrepo url ${BKREPO_URL}"
@@ -64,10 +64,10 @@ install_nginx_ingress() {
     chart_path="blueking/ingress-nginx"
   fi
   local registry
-  if [[ -n ${BK_PUBLIC_REPO} ]];then
-	registry="${BK_PUBLIC_REPO}/registry.k8s.io"
+  if [[ -n ${BK_PUBLIC_REPO} ]]; then
+    registry="${BK_PUBLIC_REPO}/registry.k8s.io"
   else
-	registry="registry.k8s.io"
+    registry="registry.k8s.io"
   fi
 
   utils::log "INFO" "installing ingress-nginx"

--- a/bcs-ops/k8s/operate_completion
+++ b/bcs-ops/k8s/operate_completion
@@ -46,9 +46,9 @@ check_completion() {
     utils::log "INFO" "installing bash-completion"
     if [[ -n ${BCS_OFFLINE:-} ]]; then
       # ToDo helm image offline install
-      rpm_path="$(find "${ROOT_DIR}/version-${VERSION}/rpm/" -iname "bash-completion-*.rpm" -type f | head -1)"
+      rpm_path="$(find "${ROOT_DIR}/version-${K8S_VER}/rpm/" -iname "bash-completion-*.rpm" -type f | head -1)"
       if [[ -z $rpm_path ]]; then
-        utils::log "FATAL" "can't find bash-completion rpm in ${ROOT_DIR}/version-${VERSION}/rpm/"
+        utils::log "FATAL" "can't find bash-completion rpm in ${ROOT_DIR}/version-${K8S_VER}/rpm/"
       fi
       rpm -ivh "$rpm_path"
     else
@@ -102,7 +102,7 @@ EOF
 
 completion_yq() {
   check_completion
-    sed -ri \
+  sed -ri \
     '/bcs config begin for yq/,/bcs config end for yq/d' ${RC_FILE}
   cat >>"$RC_FILE" <<'EOF'
 # bcs config begin for yq

--- a/bcs-ops/k8s/operate_multus
+++ b/bcs-ops/k8s/operate_multus
@@ -62,7 +62,7 @@ check_k8s_status() {
 
 check_envsubst() {
   if ! command -v envsubst &>/dev/null; then
-    utils:log "WARN" "command 'envsubst' not install, will be installed"
+    utils::log "WARN" "command 'envsubst' not install, will be installed"
     yum install gettext -y -q
   fi
 }

--- a/bcs-ops/k8s/render_kubeadm
+++ b/bcs-ops/k8s/render_kubeadm
@@ -169,6 +169,7 @@ render_init_join() {
   fi
 
   node_name="${role}-$(tr ":." "-" <<<"$LAN_IP")"
+  "${ROOT_DIR}"/system/config_bcs_dns -u "$LAN_IP" "$node_name"
 
   cat >"${config_file}" <<EOF
 apiVersion: kubeadm.k8s.io/$kubeadm_tag

--- a/bcs-ops/system/config_envfile.sh
+++ b/bcs-ops/system/config_envfile.sh
@@ -59,9 +59,12 @@ init_env() {
     LAN_IPv6="$("${ROOT_DIR}"/system/get_lan_ip -6)"
   fi
   BCS_OFFLINE=${BCS_OFFLINE:-}
+  INSTALL_METHOD=${INSTALL_METHOD:-"yum"}
 
   # cri
   CRI_TYPE=${CRI_TYPE:-"docker"}
+  ## insregistry
+  INSECURE_REGISTRY=${INSECURE_REGISTRY:-""}
   ## DOCKER
   DOCKER_VER=${DOCKER_VER:-"19.03.9"}
   DOCKER_LIB=${DOCKER_LIB:-"${BK_HOME}/lib/docker"}
@@ -95,7 +98,7 @@ init_env() {
   BCS_CP_WORKER=${BCS_CP_WORKER:-0}
 
   # csi
-  K8S_CSI=${K8S_CSI:-"localpv"}
+  K8S_CSI=${K8S_CSI:-""}
   ## localpv
   LOCALPV_DIR=${LOCALPV_DIR:-${BK_HOME}/localpv}
   LOCALPV_COUNT=${LOCALPV_COUNT:-20}
@@ -219,9 +222,11 @@ $(
 BCS_SYSCTL=${BCS_SYSCTL:=1}
 K8S_IPv6_STATUS="${K8S_IPv6_STATUS}"
 BCS_OFFLINE="${BCS_OFFLINE}"
+INSTALL_METHOD="${INSTALL_METHOD}"
 
 ## CRI
 CRI_TYPE="${CRI_TYPE}"
+INSECURE_REGISTRY=${INSECURE_REGISTRY}
 $(
     case "${CRI_TYPE,,}" in
       "containerd")

--- a/bcs-ops/tools/install_jq
+++ b/bcs-ops/tools/install_jq
@@ -30,24 +30,30 @@ safe_source() {
 }
 
 _curl_jq() {
-  local url save_file version
-  version=$1
-  url="${REPO_URL}/jq-${version}.xz"
-  save_file="/tmp/jq.xz"
-  if curl -sSfL "${url}" -o "${save_file}" -m "360"; then
-    rm -f /tmp/jq
-    unxz -dc ${save_file} >/tmp/jq
-    chmod +x /tmp/jq
-    mv /tmp/jq /usr/local/bin/jq
-    rm -f ${save_file}
+  local bin_path name ver file url
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
+  mkdir -p "$bin_path"
+
+  name="jq"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.xz"
+  url=${REPO_URL:-}/${file}
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
   else
-    utils::log "ERROR" "fail to download jq"
+    utils::log "ERROR" "fail to download ${url}"
   fi
+  _offline_jq
 }
 
 _offline_jq() {
-  # ToDo
-  true
+  local bin_path tar_name
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
+  tar_name=$(find "$bin_path" -iname "jq-*.xz" -type f | head -1)
+
+  unxz -dc "${tar_name}" >/tmp/jq
+  chmod +x /tmp/jq
+  mv /tmp/jq /usr/local/bin/jq
 }
 
 main() {

--- a/bcs-ops/tools/install_tools.sh
+++ b/bcs-ops/tools/install_tools.sh
@@ -25,67 +25,67 @@ PROJECTS=(yq jq)
 readonly SELF_DIR ROOT_DIR PROJECTS
 
 usage_and_exit() {
-    cat <<EOF
+  cat <<EOF
 Usage:
     $PROGRAM
       [ -h --help -?  show usage ]
       [ -v -V --version show script version]
       [ ${PROJECTS[*]} ]
 EOF
-    exit "$1"
+  exit "$1"
 }
 
 version() {
-    echo "$PROGRAM version $VERSION"
+  echo "$PROGRAM version $VERSION"
 }
 
 safe_source() {
-    local source_file=$1
-    if [[ -f ${source_file} ]]; then
-        #shellcheck source=/dev/null
-        source "${source_file}"
-    else
-        echo "[ERROR]: FAIL to source, missing ${source_file}"
-        exit 1
-    fi
+  local source_file=$1
+  if [[ -f ${source_file} ]]; then
+    #shellcheck source=/dev/null
+    source "${source_file}"
+  else
+    echo "[ERROR]: FAIL to source, missing ${source_file}"
+    exit 1
+  fi
 }
 
 main() {
-    local source_files
-    source_files=("${ROOT_DIR}/functions/utils.sh")
-    for file in "${source_files[@]}"; do
-        safe_source "$file"
-    done
+  local source_files
+  source_files=("${ROOT_DIR}/functions/utils.sh")
+  for file in "${source_files[@]}"; do
+    safe_source "$file"
+  done
 
-    local project
+  local project
 
-    (($# == 0)) && usage_and_exit 1
-    while (($# > 0)); do
-        case "$1" in
-            --help | -h | '-?')
-                usage_and_exit 0
-                ;;
-            --version | -v | -V)
-                version
-                exit 0
-                ;;
-            -*)
-                # ToDo: Unified standard error code
-                export ERR_CODE=1
-                utils::log "ERROR" "unkown para: $1"
-                ;;
-            *)
-                project="${ROOT_DIR}/tools/install_$1"
-                if [[ -x "${project}" ]]; then
-                    "${project}"
-                else
-                    utils::log "ERROR" "can't exec ${project}"
-                fi
-                ;;
-        esac
-        shift
-    done
-    return 0
+  (($# == 0)) && usage_and_exit 1
+  while (($# > 0)); do
+    case "$1" in
+      --help | -h | '-?')
+        usage_and_exit 0
+        ;;
+      --version | -v | -V)
+        version
+        exit 0
+        ;;
+      -*)
+        # ToDo: Unified standard error code
+        export ERR_CODE=1
+        utils::log "ERROR" "unkown para: $1"
+        ;;
+      *)
+        project="${ROOT_DIR}/tools/install_$1"
+        if [[ -x "${project}" ]]; then
+          "${project}"
+        else
+          utils::log "ERROR" "can't exec ${project}"
+        fi
+        ;;
+    esac
+    shift
+  done
+  return 0
 }
 
 main "$@"

--- a/bcs-ops/tools/install_yq
+++ b/bcs-ops/tools/install_yq
@@ -30,24 +30,30 @@ safe_source() {
 }
 
 _curl_yq() {
-  local url save_file version
-  version=$1
-  url="${REPO_URL}/yq-${version}.xz"
-  save_file="/tmp/yq.xz"
-  if curl -sSfL "${url}" -o "${save_file}" -m "360"; then
-    # rm -f /tmp/yq
-    unxz -dc ${save_file} >/tmp/yq
-    chmod +x /tmp/yq
-    mv /tmp/yq /usr/local/bin/yq
-    rm -f ${save_file}
+  local bin_path name ver file url
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
+  mkdir -p "$bin_path"
+
+  name="yq"
+  ver=$(awk '/version: \"'"${K8S_VER}"'\"/{f=1;next} f && /'"${name}"':/{gsub("\"","",$2);print $2;exit}' "${ROOT_DIR}"/env/offline-manifest.yaml)
+  file="${name}-${ver}.xz"
+  url=${REPO_URL:-}/${file}
+  if curl -sSfL "${url}" -o "${bin_path}/${file}" -m "360"; then
+    utils::log "INFO" "Downloaded ${url}"
   else
-    utils::log "ERROR" "fail to download yq: $url"
+    utils::log "ERROR" "fail to download ${url}"
   fi
+  _offline_yq
 }
 
 _offline_yq() {
-  # ToDo
-  true
+  local bin_path tar_name
+  bin_path=${ROOT_DIR}/version-${K8S_VER}/bin-tools/
+  tar_name=$(find "$bin_path" -iname "yq-*.xz" -type f | head -1)
+
+  unxz -dc "${tar_name}" >/tmp/yq
+  chmod +x /tmp/yq
+  mv /tmp/yq /usr/local/bin/yq
 }
 
 main() {


### PR DESCRIPTION
feat: 运行时 增加对 insecure_registry 的配置，新增INSECURE_REGISTRY变量 https://github.com/TencentBlueKing/bk-bcs/issues/2589#issuecomment-1752296484
feat: 支持curl方式下载离线包（for bkrepo）,新增INSTALL_METHOD变量 https://github.com/TencentBlueKing/bk-bcs/issues/2589#issuecomment-1752289366
feat: yq/jq 离线部署支持 

===
fix:
1. 离线文件路径修正为 ${ROOT_DIR}/version-${K8S_VER}
2. docker 离线部署时添加 docker 用户组
3. 离线部署时，kubeadm 不执行 config image pull style: shell-format
4. Makefile 移除无用的 bcs-ops-offline-release
5. csi取消默认配置 localpv。

===
style:
`shfmt -w -i 2 -ci -bn $(git status | awk '/modified/{printf "%s " ,$2}')`