### PR TITLE
bcs-ops: Makefile 移除旧的bcs-ops-offline

### DIFF
--- a/bcs-ops/Makefile
+++ b/bcs-ops/Makefile
@@ -11,4 +11,3 @@ build:clean
 	find ./functions/ -not -path "*/.git/*" -a -not -path "*/bin/*" -a -not -path "*/image/*" -a -not -path "*/Makefile" -type f -print0 | xargs -0 chmod 444
 	tar -czvf bcs-ops-script-release-$(VER).tar.gz  --exclude=bin --exclude=image --exclude=Makefile --exclude=\..* --exclude=.*tar.gz ./*
 	md5sum bcs-ops-script-release-$(VER).tar.gz >> MD5SUMS
-	md5sum bcs-ops-offline-release-$(VER).tar.gz >> MD5SUMS


### PR DESCRIPTION
移除旧的 `bcs-ops-offline` 