### PR TITLE
bcs-ops fix: 加固集群重启kubelet的方式。

### DIFF
--- a/bcs-ops/install_master.sh
+++ b/bcs-ops/install_master.sh
@@ -108,4 +108,4 @@ else
   fi
 fi
 
-"${ROOT_DIR}"/k8s/install_k8s
+"${ROOT_DIR}"/k8s/optimize_k8s

--- a/bcs-ops/k8s/optimize_k8s
+++ b/bcs-ops/k8s/optimize_k8s
@@ -31,7 +31,7 @@ safe_source() {
 }
 
 
-source_files=("${ROOT_DIR}/functions/utils.sh" "${ROOT_DIR}/env/bcs.env")
+source_files=("${ROOT_DIR}/functions/utils.sh" "${ROOT_DIR}/functions/k8s.sh" "${ROOT_DIR}/env/bcs.env")
 for file in "${source_files[@]}"; do
   safe_source "$file"
 done
@@ -128,6 +128,7 @@ for pod_file in ${pod_files[@]};do
   cp ${ROOT_DIR}/${pod_file} /etc/kubernetes/manifests/
 done
 
+k8s::restart_kubelet
 sleep 30
 pods=(etcd kube-apiserver kube-controller-manager kube-scheduler)
 for pod in ${pods[@]};do


### PR DESCRIPTION
doc：install_k8s 文件名重命名为optimze，更符合脚本功能