### PR TITLE
fix: 修复批量导入时，可导入其他类型kv的bug。--bug=118290565

### DIFF
--- a/bcs-services/bcs-bscp/cmd/data-service/service/kv.go
+++ b/bcs-services/bcs-bscp/cmd/data-service/service/kv.go
@@ -235,8 +235,16 @@ func (s *Service) BatchUpsertKvs(ctx context.Context, req *pbds.BatchUpsertKvsRe
 
 	kt := kit.FromGrpcContext(ctx)
 
+	app, err := s.dao.App().Get(kt, req.BizId, req.AppId)
+	if err != nil {
+		return nil, fmt.Errorf("get app fail,err : %v", err)
+	}
+
 	var editingKeyArr []string
 	for _, kv := range req.Kvs {
+		if !checkKVTypeMatch(table.DataType(kv.KvSpec.KvType), app.Spec.DataType) {
+			return nil, fmt.Errorf("kv type does not match the data type defined in the application")
+		}
 		editingKeyArr = append(editingKeyArr, kv.KvSpec.Key)
 	}
 	kvStateArr := []string{


### PR DESCRIPTION
- 新建服务为键值型且选定了数据类型可成功导入其它数据类型