### PR TITLE
feat: vault mysql storage add etcd ha backend

### DIFF
--- a/bcs-services/bcs-bscp/cmd/vault-server/vault/go.mod
+++ b/bcs-services/bcs-bscp/cmd/vault-server/vault/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 // alias github.com/hashicorp/vault release commit
 replace (
+	github.com/hashicorp/vault => github.com/ifooth/vault v0.0.0-20240122073913-369f84ba6ea4
 	github.com/hashicorp/vault/api => github.com/hashicorp/vault/api v1.9.3-0.20230721171514-bf23fe8636b0
 	github.com/hashicorp/vault/api/auth/approle => github.com/hashicorp/vault/api/auth/approle v0.4.2-0.20230721171514-bf23fe8636b0
 	github.com/hashicorp/vault/api/auth/kubernetes => github.com/hashicorp/vault/api/auth/kubernetes v0.4.2-0.20230721171514-bf23fe8636b0

--- a/bcs-services/bcs-bscp/cmd/vault-server/vault/go.sum
+++ b/bcs-services/bcs-bscp/cmd/vault-server/vault/go.sum
@@ -1846,8 +1846,6 @@ github.com/hashicorp/raft-snapshot v1.0.4/go.mod h1:5sL9eUn72lH5DzsFIJ9jaysITbHk
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
-github.com/hashicorp/vault v1.14.1 h1:JBRe4N6g6iu3yWenhlMn9PwSNAQYIQQ6PTYnbccvyxM=
-github.com/hashicorp/vault v1.14.1/go.mod h1:VH1j4CD8lYPQ+XjmgpAF7gt0M2swsARFHndbDyDRgkU=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.15.0 h1:R2SVwOeVLG5DXzUx42UWhjfFqS0Z9+ncfebPu+gO9VA=
 github.com/hashicorp/vault-plugin-auth-alicloud v0.15.0/go.mod h1:YQXpa2s4rGYKm3Oa/Nkgh5SuGVfHFNEIUwDDYWyhloE=
 github.com/hashicorp/vault-plugin-auth-azure v0.15.1 h1:CknW0l2O70326KfepWeDuPszuNherhAtVNaSLRBsS4U=
@@ -1925,6 +1923,8 @@ github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ifooth/vault v0.0.0-20240122073913-369f84ba6ea4 h1:pYiY9fDylGGhyqDQ4KdAXvXXrWfP6kbGkJDnpg6CsSE=
+github.com/ifooth/vault v0.0.0-20240122073913-369f84ba6ea4/go.mod h1:VH1j4CD8lYPQ+XjmgpAF7gt0M2swsARFHndbDyDRgkU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/bcs-services/bcs-bscp/pkg/dal/vault/vault_test.go
+++ b/bcs-services/bcs-bscp/pkg/dal/vault/vault_test.go
@@ -1,0 +1,82 @@
+package vault
+
+import (
+	"os"
+	"testing"
+
+	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/cc"
+	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/kit"
+	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/types"
+)
+
+func initClient(t testing.TB) Set {
+	vaultToken := os.Getenv("VAULT_TOKEN")
+	vaultAddr := os.Getenv("VAULT_ADDR")
+	if vaultAddr == "" || vaultToken == "" {
+		t.Skipf("VAULT_ADDR or VAULT_TOKEN env is missing")
+	}
+
+	s, err := NewSet(cc.Vault{
+		Address: vaultAddr,
+		Token:   vaultToken,
+	})
+	if err != nil {
+		t.Fatalf("new set err: %s", err)
+	}
+
+	return s
+}
+
+func TestGetKv(t *testing.T) {
+	s := initClient(t)
+	kt := kit.New()
+
+	opt := &types.GetLastKvOpt{
+		BizID: 2,
+		AppID: 1,
+		Key:   "conf",
+	}
+
+	_, _, err := s.GetLastKv(kt, opt)
+	if err != nil {
+		t.Fatalf("GetLastKv err: %s", err)
+	}
+}
+
+func BenchmarkGetKv(b *testing.B) {
+	s := initClient(b)
+	kt := kit.New()
+
+	opt := &types.GetLastKvOpt{
+		BizID: 2,
+		AppID: 1,
+		Key:   "conf",
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := s.GetLastKv(kt, opt)
+		if err != nil {
+			b.Fatalf("GetLastKv err: %s", err)
+		}
+	}
+}
+
+func BenchmarkParallelGetKv(b *testing.B) {
+	s := initClient(b)
+	kt := kit.New()
+
+	opt := &types.GetLastKvOpt{
+		BizID: 2,
+		AppID: 1,
+		Key:   "conf",
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _, err := s.GetLastKv(kt, opt)
+			if err != nil {
+				b.Fatalf("GetLastKv err: %s", err)
+			}
+		}
+	})
+}

--- a/bcs-services/bcs-bscp/pkg/dal/vault/vault_test.go
+++ b/bcs-services/bcs-bscp/pkg/dal/vault/vault_test.go
@@ -1,3 +1,15 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package vault
 
 import (


### PR DESCRIPTION
## vault 修改
- https://github.com/ifooth/vault/tree/release-v1.14.x
## 支持的配置
```hcl
storage "mysql" {
    // etcd ha 配置
    ha_lock_backend = "etcd" // 不填或者 mysql 是 db lock方式
    ha_etcd_address  = "http://localhost:2379"
    // ha_etcd_path = "/bk_bscp_vault"
    // ha_etcd_lock_timeout = "15s"
    // ha_etcd_request_timeout = "5s"
    ha_etcd_tls_ca_file = ""
    ha_etcd_tls_cert_file = ""
    ha_etcd_tls_key_file = "
}
```
## lock
<img width="549" alt="image" src="https://github.com/TencentBlueKing/bk-bcs/assets/1853121/ab88de9f-4da3-4910-82c9-2bf452027960">
