### PR TITLE
fix: upgrade modern-go/reflect2 version for kube-agent

### DIFF
--- a/bcs-services/bcs-kube-agent/go.mod
+++ b/bcs-services/bcs-kube-agent/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.7.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect


### PR DESCRIPTION
github.com/modern-go/reflect2 v1.0.1的包存在bug，会导致kube agent在使用websocket模式时启动失败，故将其升级至v1.0.2
<img width="1351" alt="image" src="https://github.com/TencentBlueKing/bk-bcs/assets/45477075/013eb4ec-bf4b-46f7-8be8-27b49752db9b">
