### PR TITLE
build: bscp dockerfile增加vault相关镜像构建

### DIFF
--- a/bcs-services/bcs-bscp/Dockerfile
+++ b/bcs-services/bcs-bscp/Dockerfile
@@ -7,5 +7,9 @@ COPY build/bk-bscp/bk-bscp-cacheservice/bk-bscp-cacheservice /bk-bscp/
 COPY build/bk-bscp/bk-bscp-configserver/bk-bscp-configserver /bk-bscp/
 COPY build/bk-bscp/bk-bscp-dataservice/bk-bscp-dataservice /bk-bscp/
 COPY build/bk-bscp/bk-bscp-feedserver/bk-bscp-feedserver /bk-bscp/
+COPY build/bk-bscp/bk-bscp-vaultserver/bk-bscp-vaultserver /bk-bscp/
+COPY build/bk-bscp/bk-bscp-vaultserver/vault /bk-bscp/
+COPY build/bk-bscp/bk-bscp-vaultserver/vault-sidecar /bk-bscp/
+COPY build/bk-bscp/bk-bscp-vaultserver/vault-plugins/bk-bscp-secret /bk-bscp/
 ENTRYPOINT ["/bscp-ui"]
 CMD []


### PR DESCRIPTION
- 支持bscp项目自身独立构建完整镜像，不依赖bcs项目