### PR TITLE
fix: vault not unseal when in db and lock lost

### DIFF
--- a/bcs-services/bcs-bscp/cmd/vault-server/vault-sidecar/server.go
+++ b/bcs-services/bcs-bscp/cmd/vault-server/vault-sidecar/server.go
@@ -98,19 +98,18 @@ func runServerCmd() error {
 		defer tick.Stop()
 
 		for range tick.C {
-			klog.InfoS("try unseal vault")
-			if err := tryUnseal(conf); err != nil {
-				klog.Warningf("unseal vault failed,err: %s", err)
-			}
-
 			// already unsealed
-			if err := checkVaultStatus(); err != nil {
-				klog.InfoS("check vault status not ready", "reason", err)
+			if err := checkVaultStatus(); err == nil {
+				klog.InfoS("check vault status already initialized and unsealed, continue")
 				continue
 			}
 
+			klog.InfoS("try unseal vault")
+			if err := tryUnseal(conf); err != nil {
+				klog.Warningf("unseal vault failed, err: %s", err)
+			}
+
 			klog.Info("unseal vault done")
-			return
 		}
 	}()
 

--- a/bcs-services/bcs-bscp/cmd/vault-server/vault-sidecar/server.go
+++ b/bcs-services/bcs-bscp/cmd/vault-server/vault-sidecar/server.go
@@ -106,7 +106,8 @@ func runServerCmd() error {
 
 			klog.InfoS("try unseal vault")
 			if err := tryUnseal(conf); err != nil {
-				klog.Warningf("unseal vault failed, err: %s", err)
+				klog.Warningf("unseal vault failed, will try later, err: %s", err)
+				continue
 			}
 
 			klog.Info("unseal vault done")


### PR DESCRIPTION
### 原因：
- db异常 -> vault(封印) -> vault ready probe / sidecar ready probe 异常 -> 现在的现象

### 其中 
- vault 为什么主动封印原因(测试了下, vault 如果只是db异常，有内存缓存，老数据获取不影响，不会主动封印；当有换锁的场景，会重新封印)
- sidecar 原则可以二次主动解封(done)
