### PR TITLE
test: replace gomonkey with xgo

### DIFF
--- a/bcs-scenarios/bcs-gitops-vaultplugin-server/go.mod
+++ b/bcs-scenarios/bcs-gitops-vaultplugin-server/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20231124101643-0d25188774c2
 	github.com/Tencent/bk-bcs/bcs-common/pkg/otel v0.0.0-20231124101643-0d25188774c2
 	github.com/Tencent/bk-bcs/bcs-scenarios/bcs-gitops-manager v0.0.0-20231124101643-0d25188774c2
-	github.com/agiledragon/gomonkey/v2 v2.11.0
 	github.com/argoproj-labs/argocd-vault-plugin v1.17.0
 	github.com/argoproj/argo-cd/v2 v2.9.2
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -51,6 +50,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/viper v1.17.0
 	github.com/stretchr/testify v1.8.4
+	github.com/xhd2015/xgo/runtime v1.0.15
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3


### PR DESCRIPTION
This PR changes test cases that use gomonkey, replacing that with xgo.

The xgo, which is a native-go solution of monkey patching, have the following advantages compared to gomonkey:
- Compatibility
  -  xgo provides support through go1.17 to go1.22, for all OS and Arch, while gomonkey has limited support
- Stability
  - xgo does not need to modify readonly area, so on MacOS developers does not need any extra setup
- Concurrent Safety
  - xgo has built-in concurrent safety, patchings are isolated among goroutines, tests do not affect each other. While gomonkey is not concurrently safe
- Simplicity
  - xgo provides a powerful API named `Patch`, which can smartly recognize the target to mock

With this introduction of xgo and removal of gomonkey, future tests can use xgo reliably.

The xgo project: https://github.com/xhd2015/xgo.

To run the tests, xgo needs to be installed:
```sh
# macOS and Linux (and WSL)
curl -fsSL https://github.com/xhd2015/xgo/raw/master/install.sh | bash

# windows
powershell -c "irm github.com/xhd2015/xgo/raw/master/install.ps1|iex"
```

Then run:
```sh
cd chaosmeta-inject-operator 
xgo test -v ./pkg/secret
```

Output:
```sh
=== RUN   TestInitProject
--- PASS: TestInitProject (0.18s)
=== RUN   TestGetSecret
--- PASS: TestGetSecret (0.00s)
=== RUN   TestGetMetadata
--- PASS: TestGetMetadata (0.00s)
=== RUN   TestListSecret
--- PASS: TestListSecret (0.00s)
=== RUN   TestCreatePutSecret
--- PASS: TestCreatePutSecret (0.00s)
=== RUN   TestDeleteSecret
--- PASS: TestDeleteSecret (0.00s)
PASS
ok      github.com/Tencent/bk-bcs/bcs-scenarios/bcs-gitops-vaultplugin-server/pkg/secret        3.235s
```