### PR TITLE
fix: 去掉客户端统计饼图和旭日图选中态的黑色边框

### DIFF
--- a/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/component-info/pie.vue
+++ b/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/component-info/pie.vue
@@ -44,6 +44,13 @@
       data: props.data,
       color: ['#2C2599', '#FFA66B', '#85CCA8', '#3E96C2'],
       interactions: [{ type: 'element-highlight' }],
+      state: {
+        active: {
+          style: {
+            stroke: '#ffffff',
+          },
+        },
+      },
       label: {
         content: ({ data }) => `${(data.percent * 100).toFixed(1)}%`,
         style: {

--- a/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/label-and-annotations/chart/pie.vue
+++ b/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/label-and-annotations/chart/pie.vue
@@ -102,6 +102,13 @@
         },
       },
       interactions: [{ type: 'element-highlight' }],
+      state: {
+        active: {
+          style: {
+            stroke: '#ffffff',
+          },
+        },
+      },
       legend: {
         position: 'right',
         offsetX: -200,
@@ -119,6 +126,13 @@
       data: sunburstData.value,
       color: ['#2C2599', '#FFA66B', '#85CCA8', '#3E96C2'],
       interactions: [{ type: 'element-highlight' }],
+      state: {
+        active: {
+          style: {
+            stroke: '#ffffff',
+          },
+        },
+      },
       label: {
         content: ({ data }) => `${(data.percent * 100).toFixed(1)}%`,
         style: {

--- a/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/pull-mass/pull-success.vue
+++ b/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/pull-mass/pull-success.vue
@@ -153,6 +153,13 @@
         autoRotate: false,
       },
       interactions: [{ type: 'element-highlight' }],
+      state: {
+        active: {
+          style: {
+            stroke: '#ffffff',
+          },
+        },
+      },
       legend: {
         position: 'bottom',
       },

--- a/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/version-release/pie.vue
+++ b/bcs-services/bcs-bscp/ui/src/views/space/client/statistics/section/version-release/pie.vue
@@ -91,6 +91,13 @@
         },
       },
       interactions: [{ type: 'element-highlight' }],
+      state: {
+        active: {
+          style: {
+            stroke: '#ffffff',
+          },
+        },
+      },
       legend: {
         layout: 'horizontal',
         position: 'right',


### PR DESCRIPTION
# Reviewed, transaction id: 8174