### PR TITLE
fix: potential path traversal attacks

### DIFF
--- a/bcs-services/bcs-bscp/cmd/api-server/service/config_import.go
+++ b/bcs-services/bcs-bscp/cmd/api-server/service/config_import.go
@@ -610,6 +610,12 @@ func (c *configImport) getAllConfigFileByApp(kt *kit.Kit, newFiles []tools.CIUni
 
 // 临时保存文件
 func saveFile(reader io.Reader, tempDir, fileName string) error {
+	if filepath.Clean(tempDir) != tempDir {
+		return fmt.Errorf("invalid temp dir: %s", tempDir)
+	}
+	if filepath.Clean(fileName) != fileName {
+		return fmt.Errorf("invalid file name: %s", fileName)
+	}
 	// 创建文件
 	file, err := os.Create(tempDir + "/" + fileName)
 	if err != nil {


### PR DESCRIPTION
修复代码扫描出的潜在路径遍历攻击风险

> [xcheck]A path traversal vulnerability occurs when user input is used unsanitized in a file path for reading. An attacker can access arbitrary files on the file system by using path traversal character sequences (../). This can lead to the disclosure of code, configuration files, and login credentials.