### PR TITLE
feat: bscp支持应用配置总数及模版套餐下模版数总数限制--  story=118111438

### DIFF
--- a/bcs-services/bcs-bscp/cmd/api-server/etc/api_server.yaml
+++ b/bcs-services/bcs-bscp/cmd/api-server/etc/api_server.yaml
@@ -50,12 +50,34 @@ repository:
       # the password to decrypt the certificate.
       password:
 
+# 特性配置
 featureFlags:
+  # 业务展示白名单
   BIZ_VIEW:
-    enabled: false
-    list:
-      - "xx"
-      - "xx"
+    # 全局默认配置(优先级低于业务级配置)，默认为true（展示）
+    default:
+    # 业务级配置，默认为空
+    spec:
+      "2":
+  # 业务资源限制
+  RESOURCE_LIMIT:
+    # 全局默认配置(优先级低于业务级配置)
+    default:
+      # 配置文件大小上限，单位为MB，默认为100MB
+      maxFileSize:
+      # 单个app下允许创建的配置数（模版+非模版），默认为2000
+      appConfigCnt:
+      # 单个模版套餐下允许创建的模版数，默认为2000
+      tmplSetTmplCnt:
+    # 业务级配置，默认为空
+    spec:
+      "2":
+        # 配置文件大小上限，单位为MB
+        maxFileSize:
+        # 单个app下允许创建的配置数（模版+非模版）
+        appConfigCnt:
+        # 单个模版套餐下允许创建的模版数
+        tmplSetTmplCnt:
 
 # defines service related settings.
 service:

--- a/bcs-services/bcs-bscp/cmd/api-server/service/handler.go
+++ b/bcs-services/bcs-bscp/cmd/api-server/service/handler.go
@@ -82,9 +82,9 @@ func FeatureFlagsHandler(w http.ResponseWriter, r *http.Request) {
 	biz := r.URL.Query().Get("biz")
 	// set biz_view feature flag
 	bizViewConf := cc.ApiServer().FeatureFlags.BizView
-	featureFlags.BizView = bizViewConf.Default
-	if enable, ok := bizViewConf.Spec[biz]; ok {
-		featureFlags.BizView = enable
+	featureFlags.BizView = *bizViewConf.Default
+	if enable, ok := bizViewConf.Spec[biz]; ok && enable != nil {
+		featureFlags.BizView = *enable
 	}
 	// set biz resource limit
 	resourceLimitConf := cc.ApiServer().FeatureFlags.ResourceLimit
@@ -93,6 +93,12 @@ func FeatureFlagsHandler(w http.ResponseWriter, r *http.Request) {
 	if resource, ok := resourceLimitConf.Spec[biz]; ok {
 		if resource.MaxFileSize != 0 {
 			featureFlags.ResourceLimit.MaxFileSize = resource.MaxFileSize
+		}
+		if resource.AppConfigCnt != 0 {
+			featureFlags.ResourceLimit.AppConfigCnt = resource.AppConfigCnt
+		}
+		if resource.TmplSetTmplCnt != 0 {
+			featureFlags.ResourceLimit.TmplSetTmplCnt = resource.TmplSetTmplCnt
 		}
 		// NOCC:golint/todo(忽略)
 		// nolint TODO：其他资源限制

--- a/bcs-services/bcs-bscp/cmd/config-server/service/app_template_binding.go
+++ b/bcs-services/bcs-bscp/cmd/config-server/service/app_template_binding.go
@@ -38,7 +38,7 @@ func (s *Service) CreateAppTemplateBinding(ctx context.Context, req *pbcs.Create
 	grpcKit := kit.FromGrpcContext(ctx)
 
 	// validate input param
-	templateSetIDs, templateIDs, err := parseBindings(req.Bindings)
+	templateSetIDs, _, err := parseBindings(req.Bindings)
 	if err != nil {
 		logs.Errorf("create app template binding failed, parse bindings err: %v, rid: %s", err, grpcKit.Rid)
 		return nil, err
@@ -47,11 +47,6 @@ func (s *Service) CreateAppTemplateBinding(ctx context.Context, req *pbcs.Create
 	repeatedTmplSetIDs := tools.SliceRepeatedElements(templateSetIDs)
 	if len(repeatedTmplSetIDs) > 0 {
 		return nil, fmt.Errorf("repeated template set ids: %v, id must be unique", repeatedTmplSetIDs)
-	}
-
-	if len(templateIDs) > 500 {
-		return nil, fmt.Errorf("the length of template ids is %d, it must be within the range of [1,500]",
-			len(templateIDs))
 	}
 
 	res := []*meta.ResourceAttribute{
@@ -122,7 +117,7 @@ func (s *Service) UpdateAppTemplateBinding(ctx context.Context, req *pbcs.Update
 	grpcKit := kit.FromGrpcContext(ctx)
 
 	// validate input param
-	templateSetIDs, templateIDs, err := parseBindings(req.Bindings)
+	templateSetIDs, _, err := parseBindings(req.Bindings)
 	if err != nil {
 		logs.Errorf("update app template binding failed, parse bindings err: %v, rid: %s", err, grpcKit.Rid)
 		return nil, err
@@ -131,11 +126,6 @@ func (s *Service) UpdateAppTemplateBinding(ctx context.Context, req *pbcs.Update
 	repeatedTmplSetIDs := tools.SliceRepeatedElements(templateSetIDs)
 	if len(repeatedTmplSetIDs) > 0 {
 		return nil, fmt.Errorf("repeated template set ids: %v, id must be unique", repeatedTmplSetIDs)
-	}
-
-	if len(templateIDs) > 500 {
-		return nil, fmt.Errorf("the length of template ids is %d, it must be within the range of [1,500]",
-			len(templateIDs))
 	}
 
 	res := []*meta.ResourceAttribute{
@@ -558,10 +548,6 @@ func (s *Service) UpdateAppBoundTmplRevisions(ctx context.Context, req *pbcs.Upd
 	repeatedTmplRevisionIDs := tools.SliceRepeatedElements(templateIDs)
 	if len(repeatedTmplRevisionIDs) > 0 {
 		return nil, fmt.Errorf("repeated template ids: %v, id must be unique", repeatedTmplRevisionIDs)
-	}
-	if len(templateIDs) > 500 {
-		return nil, fmt.Errorf("the length of template ids is %d, it must be within the range of [1,500]",
-			len(templateIDs))
 	}
 
 	res := []*meta.ResourceAttribute{

--- a/bcs-services/bcs-bscp/cmd/data-service/etc/data_service.yaml
+++ b/bcs-services/bcs-bscp/cmd/data-service/etc/data_service.yaml
@@ -110,12 +110,34 @@ sharding:
     qps: 500
     burst: 500
 
-# configLimit is config related limit
-configLimit:
-  # appConfigCnt is the max limit of config item for an app for user to create, default is 2000
-  appConfigCnt:
-  # tmplSetTmplCnt is the max limit of templates for a template set for user to create, default is 2000
-  tmplSetTmplCnt:
+# 特性配置
+featureFlags:
+  # 业务展示白名单
+  BIZ_VIEW:
+    # 全局默认配置(优先级低于业务级配置)，默认为true（展示）
+    default:
+    # 业务级配置，默认为空
+    spec:
+      "2":
+  # 业务资源限制
+  RESOURCE_LIMIT:
+    # 全局默认配置(优先级低于业务级配置)
+    default:
+      # 配置文件大小上限，单位为MB，默认为100MB
+      maxFileSize:
+      # 单个app下允许创建的配置数（模版+非模版），默认为2000
+      appConfigCnt:
+      # 单个模版套餐下允许创建的模版数，默认为2000
+      tmplSetTmplCnt:
+    # 业务级配置，默认为空
+    spec:
+      "2":
+        # 配置文件大小上限，单位为MB
+        maxFileSize:
+        # 单个app下允许创建的配置数（模版+非模版）
+        appConfigCnt:
+        # 单个模版套餐下允许创建的模版数
+        tmplSetTmplCnt:
 
 # defines log's related configuration
 log:

--- a/bcs-services/bcs-bscp/cmd/data-service/etc/data_service.yaml
+++ b/bcs-services/bcs-bscp/cmd/data-service/etc/data_service.yaml
@@ -110,6 +110,13 @@ sharding:
     qps: 500
     burst: 500
 
+# configLimit is config related limit
+configLimit:
+  # appConfigCnt is the max limit of config item for an app for user to create, default is 2000
+  appConfigCnt:
+  # tmplSetTmplCnt is the max limit of templates for a template set for user to create, default is 2000
+  tmplSetTmplCnt:
+
 # defines log's related configuration
 log:
   # log storage directory.

--- a/bcs-services/bcs-bscp/cmd/data-service/service/template.go
+++ b/bcs-services/bcs-bscp/cmd/data-service/service/template.go
@@ -85,6 +85,17 @@ func (s *Service) CreateTemplate(ctx context.Context, req *pbds.CreateTemplateRe
 		return nil, err
 	}
 
+	// validate template set's templates count.
+	for _, tmplSetID := range req.TemplateSetIds {
+		if err = s.dao.TemplateSet().ValidateTmplNumber(kt, tx, req.Attachment.BizId, tmplSetID); err != nil {
+			logs.Errorf("validate template set's templates count failed, err: %v, rid: %s", err, kt.Rid)
+			if rErr := tx.Rollback(); rErr != nil {
+				logs.Errorf("transaction rollback failed, err: %v, rid: %s", rErr, kt.Rid)
+			}
+			return nil, err
+		}
+	}
+
 	// 2. create template revision
 	spec := req.TrSpec.TemplateRevisionSpec()
 	// if no revision name is specified, generate it by system
@@ -435,6 +446,17 @@ func (s *Service) AddTmplsToTmplSets(ctx context.Context, req *pbds.AddTmplsToTm
 			logs.Errorf("transaction rollback failed, err: %v, rid: %s", rErr, kt.Rid)
 		}
 		return nil, err
+	}
+
+	// validate template set's templates count.
+	for _, tmplSetID := range req.TemplateSetIds {
+		if err := s.dao.TemplateSet().ValidateTmplNumber(kt, tx, req.BizId, tmplSetID); err != nil {
+			logs.Errorf("validate template set's templates count failed, err: %v, rid: %s", err, kt.Rid)
+			if rErr := tx.Rollback(); rErr != nil {
+				logs.Errorf("transaction rollback failed, err: %v, rid: %s", rErr, kt.Rid)
+			}
+			return nil, err
+		}
 	}
 
 	// 2. update app template bindings if necessary

--- a/bcs-services/bcs-bscp/cmd/data-service/service/template_set.go
+++ b/bcs-services/bcs-bscp/cmd/data-service/service/template_set.go
@@ -150,6 +150,15 @@ func (s *Service) UpdateTemplateSet(ctx context.Context, req *pbds.UpdateTemplat
 		return nil, err
 	}
 
+	// validate template set's templates count.
+	if err = s.dao.TemplateSet().ValidateTmplNumber(kt, tx, req.Attachment.BizId, req.Id); err != nil {
+		logs.Errorf("validate template set's templates count failed, err: %v, rid: %s", err, kt.Rid)
+		if rErr := tx.Rollback(); rErr != nil {
+			logs.Errorf("transaction rollback failed, err: %v, rid: %s", rErr, kt.Rid)
+		}
+		return nil, err
+	}
+
 	// 2. update app template bindings if necessary
 	// delete invisible template set from correspond app template bindings
 	if len(invisibleATBs) > 0 {

--- a/bcs-services/bcs-bscp/pkg/cc/service.go
+++ b/bcs-services/bcs-bscp/pkg/cc/service.go
@@ -98,6 +98,7 @@ func (s *ApiServerSetting) trySetDefault() {
 	s.Service.trySetDefault()
 	s.Log.trySetDefault()
 	s.Repo.trySetDefault()
+	s.FeatureFlags.trySetDefault()
 }
 
 // Validate ApiServerSetting option.
@@ -112,6 +113,10 @@ func (s ApiServerSetting) Validate() error {
 	}
 
 	if err := s.Repo.validate(); err != nil {
+		return err
+	}
+
+	if err := s.FeatureFlags.validate(); err != nil {
 		return err
 	}
 
@@ -279,12 +284,12 @@ type DataServiceSetting struct {
 	Service Service   `yaml:"service"`
 	Log     LogOption `yaml:"log"`
 
-	Credential  Credential  `yaml:"credential"`
-	Sharding    Sharding    `yaml:"sharding"`
-	Esb         Esb         `yaml:"esb"`
-	Repo        Repository  `yaml:"repository"`
-	Vault       Vault       `yaml:"vault"`
-	ConfigLimit ConfigLimit `yaml:"configLimit"`
+	Credential   Credential   `yaml:"credential"`
+	Sharding     Sharding     `yaml:"sharding"`
+	Esb          Esb          `yaml:"esb"`
+	Repo         Repository   `yaml:"repository"`
+	Vault        Vault        `yaml:"vault"`
+	FeatureFlags FeatureFlags `yaml:"featureFlags"`
 }
 
 // trySetFlagBindIP try set flag bind ip.
@@ -305,7 +310,7 @@ func (s *DataServiceSetting) trySetDefault() {
 	s.Sharding.trySetDefault()
 	s.Repo.trySetDefault()
 	s.Vault.getConfigFromEnv()
-	s.ConfigLimit.trySetDefault()
+	s.FeatureFlags.trySetDefault()
 }
 
 // Validate DataServiceSetting option.
@@ -335,7 +340,7 @@ func (s DataServiceSetting) Validate() error {
 		return err
 	}
 
-	if err := s.ConfigLimit.validate(); err != nil {
+	if err := s.FeatureFlags.validate(); err != nil {
 		return err
 	}
 

--- a/bcs-services/bcs-bscp/pkg/cc/service.go
+++ b/bcs-services/bcs-bscp/pkg/cc/service.go
@@ -279,11 +279,12 @@ type DataServiceSetting struct {
 	Service Service   `yaml:"service"`
 	Log     LogOption `yaml:"log"`
 
-	Credential Credential `yaml:"credential"`
-	Sharding   Sharding   `yaml:"sharding"`
-	Esb        Esb        `yaml:"esb"`
-	Repo       Repository `yaml:"repository"`
-	Vault      Vault      `yaml:"vault"`
+	Credential  Credential  `yaml:"credential"`
+	Sharding    Sharding    `yaml:"sharding"`
+	Esb         Esb         `yaml:"esb"`
+	Repo        Repository  `yaml:"repository"`
+	Vault       Vault       `yaml:"vault"`
+	ConfigLimit ConfigLimit `yaml:"configLimit"`
 }
 
 // trySetFlagBindIP try set flag bind ip.
@@ -304,6 +305,7 @@ func (s *DataServiceSetting) trySetDefault() {
 	s.Sharding.trySetDefault()
 	s.Repo.trySetDefault()
 	s.Vault.getConfigFromEnv()
+	s.ConfigLimit.trySetDefault()
 }
 
 // Validate DataServiceSetting option.
@@ -330,6 +332,10 @@ func (s DataServiceSetting) Validate() error {
 	}
 
 	if err := s.Vault.validate(); err != nil {
+		return err
+	}
+
+	if err := s.ConfigLimit.validate(); err != nil {
 		return err
 	}
 

--- a/bcs-services/bcs-bscp/pkg/cc/types.go
+++ b/bcs-services/bcs-bscp/pkg/cc/types.go
@@ -75,14 +75,14 @@ func (f FeatureFlags) validate() error {
 	for bizID := range f.BizView.Spec {
 		if _, err := strconv.Atoi(bizID); err != nil {
 			return fmt.Errorf("invalid featureFlags.BIZ_VIEW.spec.{bizID} value %s, "+
-				"biz id should be able to convert into an interger", bizID)
+				"biz id should be an interger", bizID)
 		}
 	}
 
 	for bizID := range f.ResourceLimit.Spec {
 		if _, err := strconv.Atoi(bizID); err != nil {
 			return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.spec.{bizID} value %s, "+
-				"biz id should be able to convert into an interger", bizID)
+				"biz id should be an interger", bizID)
 		}
 	}
 

--- a/bcs-services/bcs-bscp/pkg/cc/types.go
+++ b/bcs-services/bcs-bscp/pkg/cc/types.go
@@ -1101,6 +1101,45 @@ func (v *Vault) getConfigFromEnv() {
 	}
 }
 
+// ConfigLimit is config related limit
+type ConfigLimit struct {
+	// AppConfigCnt is the max limit of config item for an app for user to create
+	AppConfigCnt int `yaml:"appConfigCnt"`
+	// TmplSetTmplCnt is the max limit of templates for a template set for user to create
+	TmplSetTmplCnt int `yaml:"tmplSetTmplCnt"`
+}
+
+// validate if the config limit is valid or not.
+func (c ConfigLimit) validate() error {
+	if c.AppConfigCnt < 0 {
+		return fmt.Errorf("invalid configLimit.appConfigCnt value %d, should >= 1", c.AppConfigCnt)
+	}
+
+	if c.TmplSetTmplCnt < 0 {
+		return fmt.Errorf("invalid configLimit.tmplSetTmplCnt value %d, should >= 1", c.TmplSetTmplCnt)
+	}
+
+	return nil
+}
+
+const (
+	// DefaultAppConfigCnt is default app's config count
+	DefaultAppConfigCnt = 2000
+	// DefaultTmplSetTmplCnt is default template set's template count
+	DefaultTmplSetTmplCnt = 2000
+)
+
+// trySetDefault try set the default value of config limit
+func (c *ConfigLimit) trySetDefault() {
+	if c.AppConfigCnt == 0 {
+		c.AppConfigCnt = DefaultAppConfigCnt
+	}
+
+	if c.TmplSetTmplCnt == 0 {
+		c.TmplSetTmplCnt = DefaultTmplSetTmplCnt
+	}
+}
+
 // BKNotice defines all the bk notice related runtime.
 type BKNotice struct {
 	Enable bool   `yaml:"enable"`

--- a/bcs-services/bcs-bscp/pkg/cc/types.go
+++ b/bcs-services/bcs-bscp/pkg/cc/types.go
@@ -65,47 +65,24 @@ type ResourceLimit struct {
 	// MaxFileSize 配置文件大小上限，单位 MB，默认为100MB
 	MaxFileSize uint `json:"maxFileSize" yaml:"maxFileSize"`
 	// AppConfigCnt 单个app下允许创建的配置数（模版+非模版），默认为2000
-	AppConfigCnt int `yaml:"appConfigCnt"`
+	AppConfigCnt uint `yaml:"appConfigCnt"`
 	// TmplSetTmplCnt 单个模版套餐下允许创建的模版数，默认为2000
-	TmplSetTmplCnt int `yaml:"tmplSetTmplCnt"`
+	TmplSetTmplCnt uint `yaml:"tmplSetTmplCnt"`
 }
 
 // validate if the feature resource limit is valid or not.
 func (f FeatureFlags) validate() error {
-	if f.ResourceLimit.Default.MaxFileSize < 0 {
-		return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.default.maxFileSize value %d, should >= 1",
-			f.ResourceLimit.Default.MaxFileSize)
+	for bizID := range f.BizView.Spec {
+		if _, err := strconv.Atoi(bizID); err != nil {
+			return fmt.Errorf("invalid featureFlags.BIZ_VIEW.spec.{bizID} value %s, "+
+				"biz id should be able to convert into an interger", bizID)
+		}
 	}
 
-	if f.ResourceLimit.Default.AppConfigCnt < 0 {
-		return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.default.appConfigCnt value %d, should >= 1",
-			f.ResourceLimit.Default.AppConfigCnt)
-	}
-
-	if f.ResourceLimit.Default.TmplSetTmplCnt < 0 {
-		return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.default.tmplSetTmplCnt value %d, should >= 1",
-			f.ResourceLimit.Default.TmplSetTmplCnt)
-	}
-
-	for bizID, bizLimit := range f.ResourceLimit.Spec {
+	for bizID := range f.ResourceLimit.Spec {
 		if _, err := strconv.Atoi(bizID); err != nil {
 			return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.spec.{bizID} value %s, "+
-				"biz id should be able to converted into an interger", bizID)
-		}
-
-		if bizLimit.MaxFileSize < 0 {
-			return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.spec.%s.maxFileSize value %d, should >= 1",
-				bizID, f.ResourceLimit.Default.MaxFileSize)
-		}
-
-		if bizLimit.AppConfigCnt < 0 {
-			return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.spec.%s.appConfigCnt value %d, should >= 1",
-				bizID, f.ResourceLimit.Default.AppConfigCnt)
-		}
-
-		if bizLimit.TmplSetTmplCnt < 0 {
-			return fmt.Errorf("invalid featureFlags.RESOURCE_LIMIT.spec.%s.tmplSetTmplCnt value %d, should >= 1",
-				bizID, f.ResourceLimit.Default.TmplSetTmplCnt)
+				"biz id should be able to convert into an interger", bizID)
 		}
 	}
 

--- a/bcs-services/bcs-bscp/pkg/dal/dao/app_template_binding.go
+++ b/bcs-services/bcs-bscp/pkg/dal/dao/app_template_binding.go
@@ -127,7 +127,8 @@ func (dao *appTemplateBindingDao) GetAppTemplateBindingByAppID(kit *kit.Kit, biz
 }
 
 // CreateWithTx create one app template binding instance with transaction.
-func (dao *appTemplateBindingDao) CreateWithTx(kit *kit.Kit, tx *gen.QueryTx, g *table.AppTemplateBinding) (uint32, error) {
+func (dao *appTemplateBindingDao) CreateWithTx(kit *kit.Kit, tx *gen.QueryTx, g *table.AppTemplateBinding) (
+	uint32, error) {
 	if err := g.ValidateCreate(); err != nil {
 		return 0, err
 	}

--- a/bcs-services/bcs-bscp/pkg/dal/dao/config_item.go
+++ b/bcs-services/bcs-bscp/pkg/dal/dao/config_item.go
@@ -479,13 +479,23 @@ func (dao *configItemDao) ValidateAppCINumber(kt *kit.Kit, tx *gen.QueryTx, bizI
 	}
 
 	total := int(count) + tcount
-	if total > cc.DataService().ConfigLimit.AppConfigCnt {
+	appConfigCnt := getAppConfigCnt(bizID)
+	if total > appConfigCnt {
 		return errf.New(errf.InvalidParameter,
 			fmt.Sprintf("the total number of app %d's config items(including template and non-template)"+
-				"exceeded the limit %d", appID, cc.DataService().ConfigLimit.AppConfigCnt))
+				"exceeded the limit %d", appID, appConfigCnt))
 	}
 
 	return nil
+}
+
+func getAppConfigCnt(bizID uint32) int {
+	if resLimit, ok := cc.DataService().FeatureFlags.ResourceLimit.Spec[fmt.Sprintf("%d", bizID)]; ok {
+		if resLimit.AppConfigCnt > 0 {
+			return resLimit.AppConfigCnt
+		}
+	}
+	return cc.DataService().FeatureFlags.ResourceLimit.Default.AppConfigCnt
 }
 
 // queryFileMode query config item file mode field.

--- a/bcs-services/bcs-bscp/pkg/dal/dao/config_item.go
+++ b/bcs-services/bcs-bscp/pkg/dal/dao/config_item.go
@@ -492,10 +492,10 @@ func (dao *configItemDao) ValidateAppCINumber(kt *kit.Kit, tx *gen.QueryTx, bizI
 func getAppConfigCnt(bizID uint32) int {
 	if resLimit, ok := cc.DataService().FeatureFlags.ResourceLimit.Spec[fmt.Sprintf("%d", bizID)]; ok {
 		if resLimit.AppConfigCnt > 0 {
-			return resLimit.AppConfigCnt
+			return int(resLimit.AppConfigCnt)
 		}
 	}
-	return cc.DataService().FeatureFlags.ResourceLimit.Default.AppConfigCnt
+	return int(cc.DataService().FeatureFlags.ResourceLimit.Default.AppConfigCnt)
 }
 
 // queryFileMode query config item file mode field.

--- a/bcs-services/bcs-bscp/pkg/dal/dao/config_item.go
+++ b/bcs-services/bcs-bscp/pkg/dal/dao/config_item.go
@@ -20,6 +20,7 @@ import (
 	"gorm.io/gen/field"
 	"gorm.io/gorm"
 
+	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/cc"
 	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/criteria/errf"
 	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/dal/gen"
 	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/dal/table"
@@ -453,9 +454,6 @@ func (dao *configItemDao) validateAttachmentAppExist(kit *kit.Kit, am *table.Con
 	return nil
 }
 
-// maxConfigItemsLimitForApp defines the max limit of config item for an app for user to create.
-const maxConfigItemsLimitForApp = 2000
-
 // ValidateAppCINumber verify whether the current number of app config items has reached the maximum.
 // the number is the total count of template and non-template config items
 func (dao *configItemDao) ValidateAppCINumber(kt *kit.Kit, tx *gen.QueryTx, bizID, appID uint32) error {
@@ -481,10 +479,10 @@ func (dao *configItemDao) ValidateAppCINumber(kt *kit.Kit, tx *gen.QueryTx, bizI
 	}
 
 	total := int(count) + tcount
-	if total > maxConfigItemsLimitForApp {
+	if total > cc.DataService().ConfigLimit.AppConfigCnt {
 		return errf.New(errf.InvalidParameter,
 			fmt.Sprintf("the total number of app %d's config items(including template and non-template)"+
-				" is %d, which exceeded the limit %d", appID, total, maxConfigItemsLimitForApp))
+				"exceeded the limit %d", appID, cc.DataService().ConfigLimit.AppConfigCnt))
 	}
 
 	return nil

--- a/bcs-services/bcs-bscp/pkg/dal/dao/template_set.go
+++ b/bcs-services/bcs-bscp/pkg/dal/dao/template_set.go
@@ -517,8 +517,8 @@ func (dao *templateSetDao) ValidateTmplNumber(kt *kit.Kit, tx *gen.QueryTx, bizI
 func getTmplSetTmplCnt(bizID uint32) int {
 	if resLimit, ok := cc.DataService().FeatureFlags.ResourceLimit.Spec[fmt.Sprintf("%d", bizID)]; ok {
 		if resLimit.TmplSetTmplCnt > 0 {
-			return resLimit.TmplSetTmplCnt
+			return int(resLimit.TmplSetTmplCnt)
 		}
 	}
-	return cc.DataService().FeatureFlags.ResourceLimit.Default.TmplSetTmplCnt
+	return int(cc.DataService().FeatureFlags.ResourceLimit.Default.TmplSetTmplCnt)
 }

--- a/bcs-services/bcs-bscp/pkg/dal/dao/template_set.go
+++ b/bcs-services/bcs-bscp/pkg/dal/dao/template_set.go
@@ -20,6 +20,8 @@ import (
 	rawgen "gorm.io/gen"
 	"gorm.io/gorm"
 
+	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/cc"
+	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/criteria/errf"
 	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/dal/gen"
 	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/dal/table"
 	dtypes "github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/dal/types"
@@ -67,6 +69,8 @@ type TemplateSet interface {
 	ListAllTemplateIDs(kit *kit.Kit, bizID, templateSpaceID uint32) ([]uint32, error)
 	// ListAllTmplSetsOfBiz list all template sets of one biz
 	ListAllTmplSetsOfBiz(kit *kit.Kit, bizID, appID uint32) ([]*table.TemplateSet, error)
+	// ValidateTmplNumber verify whether the current number of template set's templates has reached the maximum.
+	ValidateTmplNumber(kt *kit.Kit, tx *gen.QueryTx, bizID, tmplSetID uint32) error
 }
 
 var _ TemplateSet = new(templateSetDao)
@@ -484,6 +488,26 @@ func (dao *templateSetDao) validateTemplatesExist(kit *kit.Kit, templateIDs []ui
 	diffIDs := tools.SliceDiff(templateIDs, existIDs)
 	if len(diffIDs) > 0 {
 		return fmt.Errorf("template id in %v is not exist", diffIDs)
+	}
+
+	return nil
+}
+
+// ValidateTmplNumber verify whether the current number of template set's templates has reached the maximum.
+func (dao *templateSetDao) ValidateTmplNumber(kt *kit.Kit, tx *gen.QueryTx, bizID, tmplSetID uint32) error {
+
+	// get template count
+	m := tx.TemplateSet
+	tmplSet, err := m.WithContext(kt.Ctx).Where(m.BizID.Eq(bizID), m.ID.Eq(tmplSetID)).Take()
+	if err != nil {
+		return fmt.Errorf("get template set %d's failed, err: %v", tmplSetID, err)
+	}
+	count := len(tmplSet.Spec.TemplateIDs)
+
+	if count > cc.DataService().ConfigLimit.TmplSetTmplCnt {
+		return errf.New(errf.InvalidParameter,
+			fmt.Sprintf("the total number of template set %d's templates exceeded the limit %d",
+				tmplSetID, cc.DataService().ConfigLimit.TmplSetTmplCnt))
 	}
 
 	return nil

--- a/bcs-services/bcs-bscp/pkg/dal/table/config_item.go
+++ b/bcs-services/bcs-bscp/pkg/dal/table/config_item.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/criteria/enumor"
-	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/criteria/errf"
 	"github.com/TencentBlueKing/bk-bcs/bcs-services/bcs-bscp/pkg/criteria/validator"
 )
 
@@ -32,18 +31,6 @@ var ConfigItemColumnDescriptor = mergeColumnDescriptors("",
 	mergeColumnDescriptors("spec", CISpecColumnDescriptor),
 	mergeColumnDescriptors("attachment", CIAttachmentColumnDescriptor),
 	mergeColumnDescriptors("revision", RevisionColumnDescriptor))
-
-// maxConfigItemsLimitForApp defines the max limit of config item for an app for user to create.
-const maxConfigItemsLimitForApp = 2000
-
-// ValidateAppCINumber verify whether the current number of app config items has reached the maximum.
-func ValidateAppCINumber(count int64) error {
-	if count > maxConfigItemsLimitForApp {
-		return errf.New(errf.InvalidParameter, fmt.Sprintf("an application only create %d config items",
-			maxConfigItemsLimitForApp))
-	}
-	return nil
-}
 
 // ConfigItem defines a basic configuration item
 type ConfigItem struct {


### PR DESCRIPTION
1. 最大单模版套餐支持2000个配置文件（数量可配置）
2. 单服务下，非配置模版配置文件数据 + 配置模版配置文件数据（可能是多个套餐） 小于等于 2000（数量可配置）