### PR TITLE
fix: 正确处理kubeconfg导入集群时的报错

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/blueking/tasks/importCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/blueking/tasks/importCluster.go
@@ -80,17 +80,23 @@ func ImportClusterNodesTask(taskID string, stepName string) error {
 	// update cluster info
 	err = cloudprovider.GetStorageModel().UpdateCluster(context.Background(), basicInfo.Cluster)
 	if err != nil {
-		return err
+		blog.Errorf("ImportClusterNodesTask[%s]: UpdateCluster failed: %v", taskID, err)
+		retErr := fmt.Errorf("UpdateCluster failed, %s", err.Error())
+		_ = state.UpdateStepFailure(start, stepName, retErr)
+		return retErr
 	}
 	// import cluster clusterCredential
 	err = importClusterCredential(basicInfo)
 	if err != nil {
 		blog.Errorf("ImportClusterNodesTask[%s]: importClusterCredential failed: %v", taskID, err)
+		retErr := fmt.Errorf("importClusterCredential failed, %s", err.Error())
+		_ = state.UpdateStepFailure(start, stepName, retErr)
+		return retErr
 	}
 
 	// update step
 	if err := state.UpdateStepSucc(start, stepName); err != nil {
-		blog.Errorf("CreateClusterShieldAlarmTask[%s] task %s %s update to storage fatal",
+		blog.Errorf("ImportClusterNodesTask[%s] task %s %s update to storage fatal",
 			taskID, taskID, stepName)
 		return err
 	}


### PR DESCRIPTION
用户使用kubeconfig导入集群时，如果kubeconfig不配置k8s集群证书，而是使用insecure-skip-tls-verify，会导致kubeconfig测试通过，导入集群成功，但是导入后获取不到集群资源。
查看日志，分析是cluster manager未正确处理导入集群时的报错导致
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/30ece9f0-ceef-4298-a04e-853a1b5bb685">
