### PR TITLE
fix: 集群概览页面磁盘 I0 监控显示不匹配

### DIFF
--- a/bcs-services/bcs-monitor/pkg/api/metrics/query/bk_monitor.go
+++ b/bcs-services/bcs-monitor/pkg/api/metrics/query/bk_monitor.go
@@ -202,7 +202,7 @@ func (h BKMonitorHandler) ClusterDiskUsage(c *rest.Context) (promclient.ResultDa
 // nolint
 func (h BKMonitorHandler) ClusterDiskioUsage(c *rest.Context) (promclient.ResultData, error) {
 	promql := `sum(max by(instance) (rate(bkmonitor:node_disk_io_time_seconds_total{bcs_cluster_id="%<clusterID>s"}[2m]))) / ` +
-		`count(max by(instance) (rate(bkmonitor:node_disk_io_time_seconds_total{bcs_cluster_id="%<clusterID>s"}[2m])))`
+		`count(max by(instance) (rate(bkmonitor:node_disk_io_time_seconds_total{bcs_cluster_id="%<clusterID>s"}[2m]))) * 100`
 
 	return h.handleBKMonitorClusterMetric(c, promql)
 }


### PR DESCRIPTION
fix: 集群概览页面磁盘 I0 监控显示不匹配