### PR TITLE
fix: CPU和内存使用率的计算增加过滤条件，修复超过100%的问题

### DIFF
--- a/bcs-services/bcs-monitor/pkg/api/metrics/query/bk_monitor.go
+++ b/bcs-services/bcs-monitor/pkg/api/metrics/query/bk_monitor.go
@@ -94,10 +94,10 @@ func (h BKMonitorHandler) GetClusterOverview(c *rest.Context) (ClusterOverviewMe
 	}
 
 	promqlMap := map[string]string{
-		"cpu_used":       `sum(rate(bkmonitor:container_cpu_usage_seconds_total{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
+		"cpu_used":       `sum(rate(bkmonitor:container_cpu_usage_seconds_total{pod_name!="", bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
 		"cpu_request":    `sum(avg_over_time(bkmonitor:kube_pod_container_resource_requests_cpu_cores{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
 		"cpu_total":      `sum(avg_over_time(bkmonitor:kube_node_status_allocatable_cpu_cores{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
-		"memory_used":    `sum(avg_over_time(bkmonitor:container_memory_usage_bytes{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
+		"memory_used":    `sum(avg_over_time(bkmonitor:container_memory_usage_bytes{pod_name!="", bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
 		"memory_request": `sum(avg_over_time(bkmonitor:kube_pod_container_resource_requests_memory_bytes{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
 		"memory_total":   `sum(avg_over_time(bkmonitor:kube_node_status_allocatable_memory_bytes{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m]))`,
 		"disk_used": `(sum(avg_over_time(bkmonitor:node_filesystem_size_bytes{bcs_cluster_id="%<clusterID>s", fstype=~"%<fstype>s", mountpoint=~"%<mountpoint>s"}[2m])) ` +
@@ -155,7 +155,7 @@ func (h BKMonitorHandler) ClusterPodUsage(c *rest.Context) (promclient.ResultDat
 // ClusterCPUUsage implements Handler.
 // nolint
 func (h BKMonitorHandler) ClusterCPUUsage(c *rest.Context) (promclient.ResultData, error) {
-	promql := `sum(rate(bkmonitor:container_cpu_usage_seconds_total{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m])) / ` +
+	promql := `sum(rate(bkmonitor:container_cpu_usage_seconds_total{pod_name!="", bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m])) / ` +
 		`sum(avg_over_time(bkmonitor:kube_node_status_allocatable_cpu_cores{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m])) * 100`
 
 	return h.handleBKMonitorClusterMetric(c, promql)
@@ -173,7 +173,7 @@ func (h BKMonitorHandler) ClusterCPURequestUsage(c *rest.Context) (promclient.Re
 // ClusterMemoryUsage implements Handler.
 // nolint
 func (h BKMonitorHandler) ClusterMemoryUsage(c *rest.Context) (promclient.ResultData, error) {
-	promql := `sum(avg_over_time(bkmonitor:container_memory_usage_bytes{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m])) / ` +
+	promql := `sum(avg_over_time(bkmonitor:container_memory_usage_bytes{pod_name!="", bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m])) / ` +
 		`sum(avg_over_time(bkmonitor:kube_node_status_allocatable_memory_bytes{bcs_cluster_id="%<clusterID>s", node!=""%<node>s}[2m])) * 100`
 
 	return h.handleBKMonitorClusterMetric(c, promql)


### PR DESCRIPTION
从监控平台获取 container 指标数据如container_cpu_usage_seconds_total，可能会包含一些汇总数据，导致最终计算结果不准确，超过100%

汇总数据的字段中，不包含pod_name等字段，只需要通过pod_name!=""等方式就可以将汇总数据过滤掉，只得到非汇总的数据，

![wecom-temp-291965-dd09f6d3e552b32e51b347a000aef0d3](https://github.com/user-attachments/assets/ee252ea6-1158-400a-b4f2-3774bcf34477)

![wecom-temp-294594-3a8d0b1522a87508aff697405f23d76c](https://github.com/user-attachments/assets/85d20f64-091a-4334-ab42-696a2f8fbf3f)
