### PR TITLE
feat: kubeconfig导入 & 云账号导入集群优化

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/importCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/importCluster.go
@@ -205,11 +205,6 @@ func importClusterInstances(data *cloudprovider.CloudDependBasicInfo) error {
 		}
 	}
 
-	err = importClusterNodesToCM(context.Background(), nodes.Items, data.Cluster.ClusterID)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/blueking/tasks/importCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/blueking/tasks/importCluster.go
@@ -173,6 +173,11 @@ func importClusterInstances(data *cloudprovider.CloudDependBasicInfo) error {
 	data.Cluster.Master = masterNodes
 	// data.Cluster.Status = icommon.StatusRunning
 
+	// 导入方式是 kubeconfig 集群节点不写入数据库
+	if data.Cluster.ClusterCategory == icommon.Importer && data.Cluster.ImportCategory == icommon.KubeConfigImport {
+		return nil
+	}
+
 	err = importClusterNodesToCM(context.Background(), nodeIPs, &cloudprovider.ListNodesOption{
 		Common:       data.CmOption,
 		ClusterVPCID: data.Cluster.VpcID,

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud-public/tasks/importCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud-public/tasks/importCluster.go
@@ -419,21 +419,6 @@ func importClusterInstances(data *cloudprovider.CloudDependBasicInfo) ([]string,
 		data.Cluster.Master = masterNodes
 	}
 
-	err = importClusterNodesToCM(context.Background(), nodeInfos, &cloudprovider.ListNodesOption{
-		Common:       data.CmOption,
-		ClusterVPCID: data.Cluster.VpcID,
-		ClusterID:    data.Cluster.ClusterID,
-		NodeTemplateID: func() string {
-			if data.NodeTemplate != nil {
-				return data.NodeTemplate.NodeTemplateID
-			}
-			return ""
-		}(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
 	return masterIPs, nodeIPs, nil
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud-public/tasks/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud-public/tasks/utils.go
@@ -14,16 +14,10 @@ package tasks
 
 import (
 	"context"
-	"errors"
-
-	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
-	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/drivers"
 
 	cmproto "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/api/clustermanager"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud-public/business"
-	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/api"
-	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/common"
 )
 
 // updateClusterSystemID set cluster systemID
@@ -74,56 +68,6 @@ func transInstanceIPToNodes(ipList []string, opt *cloudprovider.ListNodesOption)
 	}
 
 	return nodes, nil
-}
-
-func importClusterNodesToCM(ctx context.Context, workNodes []InstanceInfo, opt *cloudprovider.ListNodesOption) error {
-	var (
-		workerIps       = make([]string, 0)
-		ipToInstanceMap = make(map[string]InstanceInfo, 0)
-	)
-	for i := range workNodes {
-		workerIps = append(workerIps, workNodes[i].InstanceIP)
-		ipToInstanceMap[workNodes[i].InstanceIP] = workNodes[i]
-	}
-	nodes, err := business.ListNodesByIP(workerIps, &cloudprovider.ListNodesOption{
-		Common:       opt.Common,
-		ClusterVPCID: opt.ClusterVPCID,
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, n := range nodes {
-		node, err := cloudprovider.GetStorageModel().GetNodeByIP(ctx, n.InnerIP)
-		if err != nil && !errors.Is(err, drivers.ErrTableRecordNotFound) {
-			blog.Errorf("importClusterNodes GetNodeByIP[%s] failed: %v", n.InnerIP, err)
-			// no import node when found err
-			continue
-		}
-		n.ClusterID = opt.ClusterID
-		n.NodeTemplateID = opt.NodeTemplateID
-
-		ins, ok := ipToInstanceMap[n.InnerIP]
-		if ok && ins.InstanceStatus == api.RunningInstanceTke.String() {
-			n.Status = common.StatusRunning
-		} else {
-			n.Status = common.StatusAddNodesFailed
-		}
-
-		if node == nil {
-			err = cloudprovider.GetStorageModel().CreateNode(ctx, n)
-			if err != nil {
-				blog.Errorf("importClusterNodes CreateNode[%s] failed: %v", n.InnerIP, err)
-			}
-			continue
-		}
-		err = cloudprovider.GetStorageModel().UpdateNode(ctx, n)
-		if err != nil {
-			blog.Errorf("importClusterNodes UpdateNode[%s] failed: %v", n.InnerIP, err)
-		}
-	}
-
-	return nil
 }
 
 // updateNodeGroupCloudNodeGroupID set nodegroup cloudNodeGroupID

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/tasks/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/tasks/utils.go
@@ -147,7 +147,7 @@ func updateNodeIPByNodeID(ctx context.Context, clusterId string, n business.Inst
 	return nil
 }
 
-func transInstanceIPToNodes(ipList []string, opt *cloudprovider.ListNodesOption) ([]*cmproto.Node, error) {
+func transInstanceIPToNodes(ipList []string, opt *cloudprovider.ListNodesOption) ([]*cmproto.Node, error) { // nolint
 	nodes, err := business.ListNodesByIP(ipList, &cloudprovider.ListNodesOption{
 		Common:       opt.Common,
 		ClusterVPCID: opt.ClusterVPCID,
@@ -157,41 +157,6 @@ func transInstanceIPToNodes(ipList []string, opt *cloudprovider.ListNodesOption)
 	}
 
 	return nodes, nil
-}
-
-func importClusterNodesToCM(ctx context.Context, ipList []string, opt *cloudprovider.ListNodesOption) error {
-	nodes, err := business.ListNodesByIP(ipList, &cloudprovider.ListNodesOption{
-		Common:       opt.Common,
-		ClusterVPCID: opt.ClusterVPCID,
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, n := range nodes {
-		node, err := cloudprovider.GetStorageModel().GetNodeByIP(ctx, n.InnerIP)
-		if err != nil && !errors.Is(err, drivers.ErrTableRecordNotFound) {
-			blog.Errorf("importClusterNodes GetNodeByIP[%s] failed: %v", n.InnerIP, err)
-			// no import node when found err
-			continue
-		}
-
-		n.ClusterID = opt.ClusterID
-		n.Status = common.StatusRunning
-		if node == nil {
-			err = cloudprovider.GetStorageModel().CreateNode(ctx, n)
-			if err != nil {
-				blog.Errorf("importClusterNodes CreateNode[%s] failed: %v", n.InnerIP, err)
-			}
-			continue
-		}
-		err = cloudprovider.GetStorageModel().UpdateNode(ctx, n)
-		if err != nil {
-			blog.Errorf("importClusterNodes UpdateNode[%s] failed: %v", n.InnerIP, err)
-		}
-	}
-
-	return nil
 }
 
 // releaseClusterCIDR release cluster CIDR


### PR DESCRIPTION
kubeconfig 导入 或者 云账号导入的时候不用将集群节点录入数据库，apiserver可以实时获取，如果用户在其他平台下掉节点，这边反而会有脏数据