### PR TITLE
feat: 共享集群projectcode注解key支持后台配置

### DIFF
--- a/bcs-services/bcs-bkcmdb-synchronizer/config/bcs-bkcmdb-synchronizer.json.template
+++ b/bcs-services/bcs-bkcmdb-synchronizer/config/bcs-bkcmdb-synchronizer.json.template
@@ -45,5 +45,8 @@
     "bk_username": "${cmdb_bkUsername}",
     "server": "${cmdb_server}",
     "debug": ${cmdb_debug}
+  },
+  "shared_cluster": {
+    "annotation_key_proj_code": "${sharedCluster_annoKeyProjCode}"
   }
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -2781,7 +2781,8 @@ func (b *BcsBkcmdbSynchronizerHandler) handleNamespaceCreate(
 	}
 
 	bizid := bkCluster.BizID
-	if projectCode, ok := namespace.Annotations["io.tencent.bcs.projectcode"]; ok {
+	annotationKey := b.Syncer.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode
+	if projectCode, ok := namespace.Annotations[annotationKey]; ok {
 		gpr := pmp.GetProjectRequest{
 			ProjectIDOrCode: projectCode,
 		}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
@@ -17,12 +17,13 @@ import "github.com/Tencent/bk-bcs/bcs-common/common/conf"
 
 // BkcmdbSynchronizerOption options for CostManager
 type BkcmdbSynchronizerOption struct {
-	Synchronizer SynchronizerConfig `json:"synchronizer" value:"synchronizer"`
-	Client       ClientConfig       `json:"client"`
-	Bcslog       conf.LogConfig     `json:"bcslog"`
-	Bcsapi       BcsapiConfig       `json:"bcsapi"`
-	RabbitMQ     RabbitMQConfig     `json:"rabbitmq"`
-	CMDB         CMDBConfig         `json:"cmdb"`
+	Synchronizer  SynchronizerConfig  `json:"synchronizer" value:"synchronizer"`
+	Client        ClientConfig        `json:"client"`
+	Bcslog        conf.LogConfig      `json:"bcslog"`
+	Bcsapi        BcsapiConfig        `json:"bcsapi"`
+	RabbitMQ      RabbitMQConfig      `json:"rabbitmq"`
+	CMDB          CMDBConfig          `json:"cmdb"`
+	SharedCluster SharedClusterConfig `json:"shared_cluster"`
 }
 
 // SynchronizerConfig synchronizer config
@@ -69,4 +70,9 @@ type CMDBConfig struct {
 	BKUserName string `json:"bk_username"`
 	Server     string `json:"server"`
 	Debug      bool   `json:"debug"`
+}
+
+// SharedClusterConfig shared cluster config
+type SharedClusterConfig struct {
+	AnnotationKeyProjCode string `json:"annotation_key_proj_code"`
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -365,7 +365,7 @@ func (s *Syncer) SyncNamespaces(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Clus
 			}
 		} else {
 			bizid := bkCluster.BizID
-			if projectCode, ok := v.Data.Annotations["io.tencent.bcs.projectcode"]; ok {
+			if projectCode, ok := v.Data.Annotations[s.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode]; ok {
 				gpr := pmp.GetProjectRequest{
 					ProjectIDOrCode: projectCode,
 				}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/synchronizer/synchronizer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/synchronizer/synchronizer.go
@@ -121,6 +121,7 @@ func (s *Synchronizer) Init() {
 		blog.Errorf("init mq failed, err: %s", err.Error())
 	}
 
+	s.initSharedClusterConf()
 }
 
 func (s *Synchronizer) initTlsConfig() error {
@@ -166,6 +167,12 @@ func (s *Synchronizer) initMQ() error {
 	s.MQ = rabbitmq.NewRabbitMQ(&s.BkcmdbSynchronizerOption.RabbitMQ)
 
 	return nil
+}
+
+func (s *Synchronizer) initSharedClusterConf() {
+	if s.Syncer.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode == "" {
+		s.Syncer.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode = "io.tencent.bcs.projectcode"
+	}
 }
 
 // Run run the synchronizer

--- a/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
+++ b/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
@@ -193,6 +193,9 @@
         "enableInsTypeUsage": ${enableInsTypeUsage},
         "enableAllocateCidr": ${enableAllocateCidr}
     },
+    "sharedCluster": {
+      "annoKeyProjCode": "${bcsSharedClusterAnnoKeyProjCode}"
+    }
     "tagDepart": "${tagDepart}",
     "prefixVcluster": "${prefixVcluster}",
     "version": "${bcsClusterManagerVersion}",

--- a/bcs-services/bcs-cluster-manager/internal/actions/cluster/create_vcluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cluster/create_vcluster.go
@@ -186,11 +186,11 @@ func (ca *CreateVirtualClusterAction) validate() error {
 	}
 	if ca.req.Ns.Annotations == nil {
 		ca.req.Ns.Annotations = map[string]string{
-			utils.ProjectCode:      ca.req.ProjectCode,
+			options.GetGlobalCMOptions().SharedCluster.AnnoKeyProjCode: ca.req.ProjectCode,
 			utils.NamespaceCreator: ca.req.Creator,
 		}
 	} else {
-		ca.req.Ns.Annotations[utils.ProjectCode] = ca.req.ProjectCode
+		ca.req.Ns.Annotations[options.GetGlobalCMOptions().SharedCluster.AnnoKeyProjCode] = ca.req.ProjectCode
 		ca.req.Ns.Annotations[utils.NamespaceCreator] = ca.req.Creator
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/app/app.go
+++ b/bcs-services/bcs-cluster-manager/internal/app/app.go
@@ -865,6 +865,12 @@ func (cm *ClusterManager) initCommonHandler(router *mux.Router) error {
 	return nil
 }
 
+func (cm *ClusterManager) initSharedClusterConf() {
+	if cm.opt.SharedCluster.AnnoKeyProjCode == "" {
+		cm.opt.SharedCluster.AnnoKeyProjCode = utils.ProjectCode
+	}
+}
+
 // initHTTPService init http service
 func (cm *ClusterManager) initHTTPService() error {
 	router := mux.NewRouter()
@@ -1180,6 +1186,8 @@ func (cm *ClusterManager) Init() error {
 		blog.Errorf("initCloudTemplateConfig failed: %v", err)
 	}
 
+	// init shared cluster config
+	cm.initSharedClusterConf()
 	// init metric, pprof
 	cm.initExtraModules()
 	// init system signal handler

--- a/bcs-services/bcs-cluster-manager/internal/options/options.go
+++ b/bcs-services/bcs-cluster-manager/internal/options/options.go
@@ -291,6 +291,11 @@ type DaemonConfig struct {
 	EnableAllocateCidr bool `json:"enableAllocateCidr"`
 }
 
+// SharedClusterConfig config for shared cluster
+type SharedClusterConfig struct {
+	AnnoKeyProjCode string `json:"annoKeyProjCode"`
+}
+
 // ClusterManagerOptions options of cluster manager
 type ClusterManagerOptions struct {
 	Etcd               EtcdOption            `json:"etcd"`
@@ -325,6 +330,7 @@ type ClusterManagerOptions struct {
 	TracingConfig      conf.TracingConfig    `json:"tracingConfig"`
 	Encrypt            encryptv2.Config      `json:"encrypt"`
 	Daemon             DaemonConfig          `json:"daemon"`
+	SharedCluster      SharedClusterConfig   `json:"sharedCluster"`
 	ServerConfig
 	ClientConfig
 }

--- a/bcs-services/bcs-data-manager/cmd/options.go
+++ b/bcs-services/bcs-data-manager/cmd/options.go
@@ -118,29 +118,35 @@ type KafkaConfig struct {
 	Password  string `json:"password"`
 }
 
+// SharedClusterConfig options of shared cluster
+type SharedClusterConfig struct {
+	AnnoKeyProjCode string `json:"annoKeyProjCode"`
+}
+
 // DataManagerOptions options of data manager
 type DataManagerOptions struct {
 	conf.FileConfig
 	conf.LogConfig
 	ClientConfig
 	ServerConfig
-	Mongo                  MongoOption        `json:"mongoConf"`
-	BcsMonitorConf         BcsMonitorConfig   `json:"bcsMonitorConf"`
-	QueueConfig            QueueConfig        `json:"queueConfig"`
-	HandleConfig           HandleConfig       `json:"handleConfig"`
-	Etcd                   EtcdOption         `json:"etcd"`
-	BcsAPIConf             BcsAPIConfig       `json:"bcsApiConf"`
-	Debug                  bool               `json:"debug"`
-	FilterRules            ClusterFilterRules `json:"filterRules"`
-	AppCode                string             `json:"appCode"`
-	AppSecret              string             `json:"appSecret"`
-	ProducerConfig         ProducerConfig     `json:"producerConfig"`
-	KafkaConfig            KafkaConfig        `json:"kafkaConfig"`
-	NeedSendKafka          bool               `json:"needSendKafka"`
-	IgnoreBkMonitorCluster bool               `json:"ignoreBkMonitorCluster"`
-	QueryFromBkMonitor     bool               `json:"queryFromBkMonitor"`
-	BkbaseConfigPath       string             `json:"bkbaseConfigPath"`
-	TspiderConfigPath      string             `json:"tspiderConfigPath"`
+	Mongo                  MongoOption         `json:"mongoConf"`
+	BcsMonitorConf         BcsMonitorConfig    `json:"bcsMonitorConf"`
+	QueueConfig            QueueConfig         `json:"queueConfig"`
+	HandleConfig           HandleConfig        `json:"handleConfig"`
+	Etcd                   EtcdOption          `json:"etcd"`
+	BcsAPIConf             BcsAPIConfig        `json:"bcsApiConf"`
+	Debug                  bool                `json:"debug"`
+	FilterRules            ClusterFilterRules  `json:"filterRules"`
+	AppCode                string              `json:"appCode"`
+	AppSecret              string              `json:"appSecret"`
+	ProducerConfig         ProducerConfig      `json:"producerConfig"`
+	KafkaConfig            KafkaConfig         `json:"kafkaConfig"`
+	SharedClusterConfig    SharedClusterConfig `json:"sharedClusterConfig"`
+	NeedSendKafka          bool                `json:"needSendKafka"`
+	IgnoreBkMonitorCluster bool                `json:"ignoreBkMonitorCluster"`
+	QueryFromBkMonitor     bool                `json:"queryFromBkMonitor"`
+	BkbaseConfigPath       string              `json:"bkbaseConfigPath"`
+	TspiderConfigPath      string              `json:"tspiderConfigPath"`
 }
 
 // ClusterFilterRules rules for cluster filter

--- a/bcs-services/bcs-data-manager/cmd/server.go
+++ b/bcs-services/bcs-data-manager/cmd/server.go
@@ -124,6 +124,8 @@ func (s *Server) Init() error {
 		return err
 	}
 
+	// init shared cluster config
+	s.initSharedClusterConf()
 	// init metric, pprof
 	s.initExtraModules()
 	// init system signal handler
@@ -445,7 +447,7 @@ func (s *Server) initWorker() error {
 	}
 	// init resourceGetter
 	s.resourceGetter = common.NewGetter(s.opt.FilterRules.NeedFilter, selectClusters, s.opt.FilterRules.Env,
-		pmClient, bcsMonitorCli)
+		s.opt.SharedClusterConfig.AnnoKeyProjCode, pmClient, bcsMonitorCli)
 	// init producer
 	producerCron := cron.New()
 	s.producer = worker.NewProducer(s.ctx, msgQueue, producerCron, cmCli, k8sStorageCli, mesosStorageCli,
@@ -654,6 +656,13 @@ func (s *Server) initStorageCli() (bcsapi.Storage, bcsapi.Storage, error) {
 	}
 	blog.Infof("init mesos storage cli success")
 	return k8sStorageCli, mesosStorageCli, nil
+}
+
+// initSharedClusterConf init shared cluster config
+func (s *Server) initSharedClusterConf() {
+	if s.opt.SharedClusterConfig.AnnoKeyProjCode == "" {
+		s.opt.SharedClusterConfig.AnnoKeyProjCode = types.AnnotationKeyProjectCode
+	}
 }
 
 // initExtraModules xxx

--- a/bcs-services/bcs-data-manager/image/bcs-data-manager.json.template
+++ b/bcs-services/bcs-data-manager/image/bcs-data-manager.json.template
@@ -70,6 +70,9 @@
       "username": "${kafkaUsername}",
       "password": "${kafkaPassword}"
   },
+  "sharedClusterConfig": {
+      "annoKeyProjCode": "${sharedClusterAnnoKeyProjCode}"
+  }
   "bkbaseConfigPath": "${bkbaseConfigPath}",
   "tspiderConfigPath": "${tspiderConfigPath}"
 }

--- a/bcs-services/bcs-data-manager/pkg/common/common.go
+++ b/bcs-services/bcs-data-manager/pkg/common/common.go
@@ -60,28 +60,30 @@ type GetterInterface interface {
 
 // ResourceGetter common resource getter
 type ResourceGetter struct {
-	needFilter     bool
-	clusterIDs     map[string]bool
-	env            string
-	cache          *cache.Cache
-	projectManager bcsproject.BcsProjectManagerClient
-	bcsMonitorCli  bcsmonitor.ClientInterface
+	needFilter      bool
+	clusterIDs      map[string]bool
+	env             string
+	cache           *cache.Cache
+	projectManager  bcsproject.BcsProjectManagerClient
+	bcsMonitorCli   bcsmonitor.ClientInterface
+	AnnoKeyProjCode string
 }
 
 // NewGetter new common resource getter
-func NewGetter(needFilter bool, clusterIds []string, env string,
+func NewGetter(needFilter bool, clusterIds []string, env string, annoKeyProjCode string,
 	pmClient bcsproject.BcsProjectManagerClient, bcsMonitorCli bcsmonitor.ClientInterface) GetterInterface {
 	clusterMap := make(map[string]bool, len(clusterIds))
 	for index := range clusterIds {
 		clusterMap[clusterIds[index]] = true
 	}
 	return &ResourceGetter{
-		needFilter:     needFilter,
-		clusterIDs:     clusterMap,
-		env:            env,
-		cache:          cache.New(time.Minute*10, time.Minute*60),
-		projectManager: pmClient,
-		bcsMonitorCli:  bcsMonitorCli,
+		needFilter:      needFilter,
+		clusterIDs:      clusterMap,
+		env:             env,
+		cache:           cache.New(time.Minute*10, time.Minute*60),
+		projectManager:  pmClient,
+		bcsMonitorCli:   bcsMonitorCli,
+		AnnoKeyProjCode: annoKeyProjCode,
 	}
 }
 
@@ -449,7 +451,7 @@ func (g *ResourceGetter) GetK8sNamespaceList(ctx context.Context, clusterMeta *t
 	for _, namespace := range namespaces {
 		if clusterLabel != nil && clusterLabel["isShared"] == "true" {
 			nsAnnotation := namespace.Data.Annotations
-			if projectCode, ok := nsAnnotation["io.tencent.bcs.projectcode"]; ok {
+			if projectCode, ok := nsAnnotation[g.AnnoKeyProjCode]; ok {
 				namespaceProjectCode = projectCode
 				project, err := g.GetProjectInfo(ctx, "", namespaceProjectCode, pmCli)
 				if err != nil {

--- a/bcs-services/bcs-data-manager/pkg/types/types.go
+++ b/bcs-services/bcs-data-manager/pkg/types/types.go
@@ -106,6 +106,12 @@ const (
 	SecondTimeFormat = "2006-01-02 15:04:05"
 )
 
+// Shared cluster
+const (
+	// AnnotationKeyProjectCode default project code annotation key
+	AnnotationKeyProjectCode = "io.tencent.bcs.projectcode"
+)
+
 // ProjectMeta meta for project
 type ProjectMeta struct {
 	ProjectID   string            `json:"projectID"`

--- a/bcs-services/bcs-helm-manager/internal/app/app.go
+++ b/bcs-services/bcs-helm-manager/internal/app/app.go
@@ -143,6 +143,7 @@ func (hm *HelmManager) Init() error {
 		hm.initRegistry,
 		hm.initJWTClient,
 		hm.initIAMClient,
+		hm.initSharedClusterConf,
 		hm.InitComponentConfig,
 		hm.initDiscovery,
 		hm.initMicro,
@@ -601,6 +602,14 @@ func (hm *HelmManager) initIAMClient() error {
 	auth.IAMClient = iamClient
 	auth.InitPermClient(iamClient)
 	blog.Info("init iam client successfully")
+	return nil
+}
+
+// initSharedClusterConf init conf value for shared cluster
+func (hm *HelmManager) initSharedClusterConf() error {
+	if hm.opt.SharedCluster.AnnotationKeyProjCode == "" {
+		hm.opt.SharedCluster.AnnotationKeyProjCode = common.AnnotationKeyProjectCode
+	}
 	return nil
 }
 

--- a/bcs-services/bcs-helm-manager/internal/auth/iam.go
+++ b/bcs-services/bcs-helm-manager/internal/auth/iam.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-helm-manager/internal/component"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-helm-manager/internal/options"
 )
 
 var (
@@ -37,9 +38,6 @@ var (
 	ClusterIamClient *cluster.BCSClusterPerm
 	// NamespaceIamClient namespace iam client
 	NamespaceIamClient *namespace.BCSNamespacePerm
-
-	// ProjCodeAnnoKey 项目 Code 在命名空间 Annotations 中的 Key
-	ProjCodeAnnoKey = "io.tencent.bcs.projectcode"
 )
 
 // InitPermClient new a perm client
@@ -105,7 +103,7 @@ func ReleaseResourcePermCheck(projectCode, clusterID string, namespaceCreated, c
 		if err != nil {
 			return false, "", nil, err
 		}
-		if ns.Annotations[ProjCodeAnnoKey] != projectCode {
+		if ns.Annotations[options.GlobalOptions.SharedCluster.AnnotationKeyProjCode] != projectCode {
 			return false, "", nil, fmt.Errorf("命名空间 %s 在该共享集群中不属于指定项目", v)
 		}
 	}

--- a/bcs-services/bcs-helm-manager/internal/common/constant.go
+++ b/bcs-services/bcs-helm-manager/internal/common/constant.go
@@ -51,3 +51,9 @@ const (
 	// LangCookieName 语言版本 Cookie 名称
 	LangCookieName = "blueking_language"
 )
+
+// shared cluster
+const (
+	// AnnotationKeyProjectCode namespace 的 projectcode 注解 key 默认值
+	AnnotationKeyProjectCode = "io.tencent.bcs.projectcode"
+)

--- a/bcs-services/bcs-helm-manager/internal/options/options.go
+++ b/bcs-services/bcs-helm-manager/internal/options/options.go
@@ -160,21 +160,27 @@ type EncryptSecret struct {
 	Secret string `json:"secret" yaml:"secret"`
 }
 
+// SharedClusterConfig options of shared cluster config
+type SharedClusterConfig struct {
+	AnnotationKeyProjCode string `json:"annotationKeyProjCode" yaml:"annotationKeyProjCode"`
+}
+
 // HelmManagerOptions options of helm manager
 type HelmManagerOptions struct {
-	Etcd          EtcdOption         `json:"etcd" yaml:"etcd"`
-	BcsLog        LogConfig          `json:"log" yaml:"log"`
-	Swagger       SwaggerConfig      `json:"swagger" yaml:"swagger"`
-	Mongo         MongoConfig        `json:"mongo" yaml:"mongo"`
-	Repo          RepoConfig         `json:"repo" yaml:"repo"`
-	Release       ReleaseConfig      `json:"release" yaml:"release"`
-	IAM           IAMConfig          `json:"iam" yaml:"iam"`
-	JWT           JWTConfig          `json:"jwt" yaml:"jwt"`
-	Credentials   []Credential       `json:"credentials" yaml:"credentials"`
-	Encrypt       Encrypt            `json:"encrypt" yaml:"encrypt"`
-	Debug         bool               `json:"debug" yaml:"debug"`
-	TLS           TLS                `json:"tls" yaml:"tls"`
-	TracingConfig conf.TracingConfig `json:"tracingConfig" yaml:"tracingConfig"`
+	Etcd          EtcdOption          `json:"etcd" yaml:"etcd"`
+	BcsLog        LogConfig           `json:"log" yaml:"log"`
+	Swagger       SwaggerConfig       `json:"swagger" yaml:"swagger"`
+	Mongo         MongoConfig         `json:"mongo" yaml:"mongo"`
+	Repo          RepoConfig          `json:"repo" yaml:"repo"`
+	Release       ReleaseConfig       `json:"release" yaml:"release"`
+	IAM           IAMConfig           `json:"iam" yaml:"iam"`
+	JWT           JWTConfig           `json:"jwt" yaml:"jwt"`
+	Credentials   []Credential        `json:"credentials" yaml:"credentials"`
+	Encrypt       Encrypt             `json:"encrypt" yaml:"encrypt"`
+	Debug         bool                `json:"debug" yaml:"debug"`
+	TLS           TLS                 `json:"tls" yaml:"tls"`
+	TracingConfig conf.TracingConfig  `json:"tracingConfig" yaml:"tracingConfig"`
+	SharedCluster SharedClusterConfig `json:"sharedCluster" yaml:"sharedCluster"`
 	ServerConfig
 }
 

--- a/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
+++ b/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
@@ -92,4 +92,5 @@ taskConfig:
   address: ""
   exchange: ""
   workerCnt: ""
-
+sharedClusterConfig:
+  annoKeyProjCode: ""

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create-callback.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create-callback.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/bcscc"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/clientset"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/iam"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/config"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/logging"
 	nsm "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/store/namespace"
 	vdm "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/store/variabledefinition"
@@ -66,8 +67,8 @@ func (a *SharedNamespaceAction) CreateNamespaceCallback(ctx context.Context,
 		namespace := &corev1.Namespace{}
 		namespace.SetName(ns.Name)
 		namespace.SetAnnotations(map[string]string{
-			constant.AnnotationKeyProjectCode: req.GetProjectCode(),
-			constant.AnnotationKeyCreator:     ns.Creator,
+			config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode: req.GetProjectCode(),
+			constant.AnnotationKeyCreator:                         ns.Creator,
 		})
 		_, err = client.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
 		if err != nil {

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/actions/namespace/independent"
-	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/envs"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/clientset"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/itsm"
@@ -50,7 +49,7 @@ func (a *SharedNamespaceAction) CreateNamespace(ctx context.Context,
 	if !config.GlobalConf.ITSM.Enable {
 		ia := independent.NewIndependentNamespaceAction(a.model)
 		req.Annotations = append(req.Annotations, &proto.Annotation{
-			Key:   constant.AnnotationKeyProjectCode,
+			Key:   config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode,
 			Value: req.GetProjectCode(),
 		})
 		return ia.CreateNamespace(ctx, req, resp)

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/native-list.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/native-list.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/clientset"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/config"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/logging"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/util/errorx"
 	nsutils "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/util/namespace"
@@ -48,7 +49,7 @@ func (a *SharedNamespaceAction) ListNativeNamespaces(ctx context.Context,
 	}
 	retDatas := []*proto.NativeNamespaceData{}
 	for _, namespace := range namespaces {
-		projectCode, ok := namespace.Annotations[constant.AnnotationKeyProjectCode]
+		projectCode, ok := namespace.Annotations[config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode]
 		if !ok {
 			continue
 		}

--- a/bcs-services/bcs-project-manager/internal/common/envs/envs.go
+++ b/bcs-services/bcs-project-manager/internal/common/envs/envs.go
@@ -14,6 +14,7 @@
 package envs
 
 import (
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/util/stringx"
 )
 
@@ -28,4 +29,7 @@ var (
 	// BCSGatewayToken bcs gateway token
 	BCSGatewayToken    = stringx.GetEnv("gatewayToken", "")
 	BCSNamespacePrefix = stringx.GetEnv("BCS_NAMESPACE_PREFIX", "bcs")
+
+	// AnnotationKeyProjectCode shared cluster project code annotation key
+	AnnotationKeyProjectCode = stringx.GetEnv("annotationKeyProjectCode", constant.AnnotationKeyProjectCode)
 )

--- a/bcs-services/bcs-project-manager/internal/config/config.go
+++ b/bcs-services/bcs-project-manager/internal/config/config.go
@@ -180,6 +180,11 @@ type TaskConfig struct {
 	WorkerCnt    int    `yaml:"workerCnt"`
 }
 
+// SharedClusterConfig 共享集群相关配置
+type SharedClusterConfig struct {
+	AnnoKeyProjCode string `yaml:"annoKeyProjCode"`
+}
+
 // ProjectConfig 项目的配置信息
 type ProjectConfig struct {
 	Etcd                       EtcdConfig                   `yaml:"etcd"`
@@ -201,6 +206,7 @@ type ProjectConfig struct {
 	TracingConfig              conf.TracingConfig           `yaml:"tracingConfig"`
 	RestrictAuthorizedProjects bool                         `yaml:"restrictAuthorizedProjects"`
 	TaskConfig                 TaskConfig                   `yaml:"taskConfig"`
+	SharedClusterConfig        SharedClusterConfig          `yaml:"sharedClusterConfig"`
 }
 
 func (conf *ProjectConfig) initServerAddress() {
@@ -219,6 +225,9 @@ func (conf *ProjectConfig) initFromEnv() {
 	}
 	if conf.BcsGateway.Token == "" {
 		conf.BcsGateway.Token = envs.BCSGatewayToken
+	}
+	if conf.SharedClusterConfig.AnnoKeyProjCode == "" {
+		conf.SharedClusterConfig.AnnoKeyProjCode = envs.AnnotationKeyProjectCode
 	}
 }
 

--- a/bcs-services/bcs-project-manager/internal/util/namespace/namespace.go
+++ b/bcs-services/bcs-project-manager/internal/util/namespace/namespace.go
@@ -17,13 +17,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/config"
 )
 
 // FilterNamespaces filter shared namespace
 func FilterNamespaces(namespaceList *corev1.NamespaceList, shared bool, projectCode string) []corev1.Namespace {
 	nsList := []corev1.Namespace{}
 	for _, ns := range namespaceList.Items {
-		if shared && ns.Annotations[constant.AnnotationKeyProjectCode] != projectCode {
+		if shared && ns.Annotations[config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode] != projectCode {
 			continue
 		}
 		nsList = append(nsList, ns)

--- a/bcs-services/cluster-resources/etc/conf.yaml
+++ b/bcs-services/cluster-resources/etc/conf.yaml
@@ -118,7 +118,7 @@ crGlobal:
   sharedCluster:
     enabledCObjKinds: []
     enabledCRDs: []
-
+    annotationKeyProjectCode: ""
   # TRACING 相关配置
 tracing:
   tracingEnabled: false

--- a/bcs-services/cluster-resources/pkg/common/conf/conf.go
+++ b/bcs-services/cluster-resources/pkg/common/conf/conf.go
@@ -22,6 +22,8 @@ const (
 	ProjectMgrServiceName = "project.bkbcs.tencent.com"
 	// ClusterMgrServiceName 集群管理服务名
 	ClusterMgrServiceName = "clustermanager.bkbcs.tencent.com"
+	// ProjectCodeAnnoKey 命名空间所属 projectcode 注解 key 的默认值
+	ProjectCodeAnnoKey = "io.tencent.bcs.projectcode"
 	// LangCookieName 语言版本 Cookie 名称
 	LangCookieName = "blueking_language"
 	// MaxGrpcMsgSize 单请求/响应体最大尺寸 64MB

--- a/bcs-services/cluster-resources/pkg/config/config.go
+++ b/bcs-services/cluster-resources/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
+	constant "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/envs"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/errcode"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/util/errorx"
@@ -64,6 +65,10 @@ func LoadConf(filePath string) (*ClusterResourcesConf, error) {
 	}
 	if conf.Global.IAM.Host == "" {
 		conf.Global.IAM.Host = envs.BKIAMHost
+	}
+
+	if conf.Global.SharedCluster.AnnotationKeyProjectCode == "" {
+		conf.Global.SharedCluster.AnnotationKeyProjectCode = constant.ProjectCodeAnnoKey
 	}
 
 	if conf.Redis.Password == "" {
@@ -339,8 +344,9 @@ type IAMConf struct {
 
 // SharedClusterConf 共享集群相关配置
 type SharedClusterConf struct {
-	EnabledCObjKinds []string `yaml:"enabledCObjKinds" usage:"共享集群中支持的自定义对象 Kind"`
-	EnabledCRDs      []string `yaml:"enabledCRDs" usage:"共享集群中支持的 CRD"` // nolint:tagliatelle
+	EnabledCObjKinds         []string `yaml:"enabledCObjKinds" usage:"共享集群中支持的自定义对象 Kind"`
+	EnabledCRDs              []string `yaml:"enabledCRDs" usage:"共享集群中支持的 CRD"` // nolint:tagliatelle
+	AnnotationKeyProjectCode string   `yaml:"annotationKeyProjectCode" usage:"共享集群ProjectCode注解的key"`
 }
 
 // MultiClusterConf 多集群相关配置

--- a/bcs-services/cluster-resources/pkg/handler/testing.go
+++ b/bcs-services/cluster-resources/pkg/handler/testing.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/action"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/cluster"
+	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/ctxkey"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/envs"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/component/project"
@@ -102,7 +103,8 @@ func GetOrCreateNS(namespace string) error {
 	if err != nil {
 		_ = mapx.SetItems(nsManifest4Test, "metadata.name", namespace)
 		if namespace == envs.TestSharedClusterNS {
-			_ = mapx.SetItems(nsManifest4Test, []string{"metadata", "annotations", cli.ProjCodeAnnoKey}, envs.TestProjectCode)
+			_ = mapx.SetItems(nsManifest4Test, []string{
+				"metadata", "annotations", conf.ProjectCodeAnnoKey}, envs.TestProjectCode)
 		}
 		_, err = nsCli.Create(ctx, nsManifest4Test, false, metav1.CreateOptions{})
 	}

--- a/bcs-services/cluster-resources/pkg/resource/client/ns.go
+++ b/bcs-services/cluster-resources/pkg/resource/client/ns.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/ctxkey"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/errcode"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/component/project"
+	conf "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/config"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/i18n"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/iam"
 	clusterAuth "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/iam/perm/resource/cluster"
@@ -31,11 +32,6 @@ import (
 	resCsts "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/resource/constants"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/util/errorx"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/util/mapx"
-)
-
-const (
-	// ProjCodeAnnoKey 项目 Code 在命名空间 Annotations 中的 Key
-	ProjCodeAnnoKey = "io.tencent.bcs.projectcode"
 )
 
 // NSClient xxx
@@ -162,8 +158,11 @@ func filterProjNSList(ctx context.Context, manifest map[string]interface{}) (map
 func isProjNSinSharedCluster(manifest map[string]interface{}, projectCode string) bool {
 	// 规则：属于项目的命名空间满足以下两点，但这里只需要检查 annotations 即可
 	//   1. 命名(name) 以 ieg-{project_code}- 开头
-	//   2. annotations 中包含 io.tencent.bcs.projectcode: {project_code}
-	return mapx.GetStr(manifest, []string{"metadata", "annotations", ProjCodeAnnoKey}) == projectCode
+	//   2. annotations 中包含 {annotation_key_project_code}: {project_code}
+	//   3. {annotation_key_project_code} 默认值为 io.tencent.bcs.projectcode
+	return mapx.GetStr(manifest, []string{
+		"metadata", "annotations", conf.G.SharedCluster.AnnotationKeyProjectCode,
+	}) == projectCode
 }
 
 // NSWatcher xxx


### PR DESCRIPTION
目前共享集群中命名空间所属的项目都是通过 io.tencent.bcs.projectcode 这个注解来区分的，有场景的使用需求是这个注解的key是可配置的。
修改涉及以下模块：

- project-mananger
- data-manager
- cluster-resource
- helm-manager
- cluster-manager
- cmdb-synchronizer

以上模块配置中增加了对该值的配置字段，在调用处替换为使用配置值。在初始化时为配置该字段则默认使用 io.tencent.bcs.projectcode，兼容原有配置。