### PR TITLE
feat: project-manager itsm-migrate 幂等优化

### DIFF
--- a/bcs-services/bcs-project-manager/internal/store/config/config.go
+++ b/bcs-services/bcs-project-manager/internal/store/config/config.go
@@ -39,7 +39,12 @@ const (
 	ConfigKeyUpdateNamespaceItsmServiceID = "update_namespace_itsm_service_id"
 	// ConfigKeyDeleteNamespaceItsmServiceID used to create an itsm ticket when deleting a namespace in a shared cluster
 	ConfigKeyDeleteNamespaceItsmServiceID = "delete_namespace_itsm_service_id"
-
+	// ConfigCreateNamespaceItsmServiceName used to create an itsm service when creating a namespace in a shared cluster
+	ConfigCreateNamespaceItsmServiceName = "创建共享集群命名空间"
+	// ConfigUpdateNamespaceItsmServiceName used to create an itsm service when updating a namespace in a shared cluster
+	ConfigUpdateNamespaceItsmServiceName = "更新共享集群命名空间"
+	// ConfigDeleteNamespaceItsmServiceName used to create an itsm service when deleting a namespace in a shared cluster
+	ConfigDeleteNamespaceItsmServiceName = "删除共享集群命名空间"
 	// QuotaManagerCommonItsmServiceID used to create an itsm ticket when quota manager
 	QuotaManagerCommonItsmServiceID = "quota_manager_common_itsm_service_id"
 )

--- a/bcs-services/bcs-project-manager/script/migrations/itsm/migrate.go
+++ b/bcs-services/bcs-project-manager/script/migrations/itsm/migrate.go
@@ -17,16 +17,14 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"text/template"
 
-	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/drivers"
-
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/itsm"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/config"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/logging"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/store"
 	cm "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/store/config"
 )
@@ -144,16 +142,9 @@ func createITSMCatalog() (uint32, error) {
 func importCreateNamespaceService(catalogID uint32) error {
 	// check whether the service has been imported before
 	// if not, import it, else update it.
-
-	var imported bool
-	serviceIDStr, err := model.GetConfig(context.Background(), cm.ConfigKeyCreateNamespaceItsmServiceID)
-	if err != nil && !errors.Is(err, drivers.ErrTableRecordNotFound) {
+	serviceID, err := getServiceIDByName(catalogID, cm.ConfigCreateNamespaceItsmServiceName)
+	if err != nil {
 		return err
-	}
-	if err == nil {
-		imported = true
-	} else {
-		imported = false
 	}
 	// 自定义模板分隔符为 [[ ]]，例如 [[ .Name ]]，避免和 ITSM 模板变量格式冲突
 	tmpl, err := template.New("create_shared_namespace.json.tpl").Delims("[[", "]]").
@@ -175,8 +166,8 @@ func importCreateNamespaceService(catalogID uint32) error {
 	}
 	importReq := itsm.ImportServiceReq{
 		Key:             "request",
-		Name:            "创建共享集群命名空间",
-		Desc:            "创建共享集群命名空间",
+		Name:            cm.ConfigCreateNamespaceItsmServiceName,
+		Desc:            cm.ConfigCreateNamespaceItsmServiceName,
 		CatelogID:       catalogID,
 		Owners:          "admin",
 		CanTicketAgency: false,
@@ -187,37 +178,33 @@ func importCreateNamespaceService(catalogID uint32) error {
 		ProjectKey:      "0",
 		Workflow:        mp,
 	}
-	var serviceID int
-	if !imported {
+	if serviceID == 0 {
+		logging.Info("service(name: %s) not found in itsm, creating", cm.ConfigCreateNamespaceItsmServiceName)
 		serviceID, err = itsm.ImportService(importReq)
 		if err != nil {
 			return err
 		}
-		return model.SetConfig(context.Background(), cm.ConfigKeyCreateNamespaceItsmServiceID,
-			strconv.Itoa(serviceID))
+	} else {
+		logging.Info("service(name: %s, id: %d) found in itsm, updating",
+			cm.ConfigCreateNamespaceItsmServiceName, serviceID)
+		err = itsm.UpdateService(itsm.UpdateServiceReq{
+			ID:               serviceID,
+			ImportServiceReq: importReq,
+		})
+		if err != nil {
+			return err
+		}
 	}
-	serviceID, err = strconv.Atoi(serviceIDStr)
-	if err != nil {
-		return err
-	}
-	return itsm.UpdateService(itsm.UpdateServiceReq{
-		ID:               serviceID,
-		ImportServiceReq: importReq,
-	})
+	return model.SetConfig(context.Background(), cm.ConfigKeyCreateNamespaceItsmServiceID,
+		strconv.Itoa(serviceID))
 }
 
 func importUpdateNamespaceService(catalogID uint32) error {
 	// check whether the service has been imported before
 	// if not, import it, else update it.
-	var imported bool
-	serviceIDStr, err := model.GetConfig(context.Background(), cm.ConfigKeyUpdateNamespaceItsmServiceID)
-	if err != nil && !errors.Is(err, drivers.ErrTableRecordNotFound) {
+	serviceID, err := getServiceIDByName(catalogID, cm.ConfigUpdateNamespaceItsmServiceName)
+	if err != nil {
 		return err
-	}
-	if err == nil {
-		imported = true
-	} else {
-		imported = false
 	}
 	// 自定义模板分隔符为 [[ ]]，例如 [[ .Name ]]，避免和 ITSM 模板变量格式冲突
 	tmpl, err := template.New("update_shared_namespace.json.tpl").Delims("[[", "]]").
@@ -239,8 +226,8 @@ func importUpdateNamespaceService(catalogID uint32) error {
 	}
 	importReq := itsm.ImportServiceReq{
 		Key:             "request",
-		Name:            "更新共享集群命名空间",
-		Desc:            "更新共享集群命名空间",
+		Name:            cm.ConfigUpdateNamespaceItsmServiceName,
+		Desc:            cm.ConfigUpdateNamespaceItsmServiceName,
 		CatelogID:       catalogID,
 		Owners:          "admin",
 		CanTicketAgency: false,
@@ -251,37 +238,33 @@ func importUpdateNamespaceService(catalogID uint32) error {
 		ProjectKey:      "0",
 		Workflow:        mp,
 	}
-	var serviceID int
-	if !imported {
+	if serviceID == 0 {
+		logging.Info("service(name: %s) not found in itsm, creating", cm.ConfigUpdateNamespaceItsmServiceName)
 		serviceID, err = itsm.ImportService(importReq)
 		if err != nil {
 			return err
 		}
-		return model.SetConfig(context.Background(), cm.ConfigKeyUpdateNamespaceItsmServiceID,
-			strconv.Itoa(serviceID))
+	} else {
+		logging.Info("service(name: %s, id: %d) found in itsm, updating",
+			cm.ConfigUpdateNamespaceItsmServiceName, serviceID)
+		err = itsm.UpdateService(itsm.UpdateServiceReq{
+			ID:               serviceID,
+			ImportServiceReq: importReq,
+		})
+		if err != nil {
+			return err
+		}
 	}
-	serviceID, err = strconv.Atoi(serviceIDStr)
-	if err != nil {
-		return err
-	}
-	return itsm.UpdateService(itsm.UpdateServiceReq{
-		ID:               serviceID,
-		ImportServiceReq: importReq,
-	})
+	return model.SetConfig(context.Background(), cm.ConfigKeyUpdateNamespaceItsmServiceID,
+		strconv.Itoa(serviceID))
 }
 
 func importDeleteNamespaceService(catalogID uint32) error {
 	// check whether the service has been imported before
 	// if not, import it, else update it.
-	var imported bool
-	serviceIDStr, err := model.GetConfig(context.Background(), cm.ConfigKeyDeleteNamespaceItsmServiceID)
-	if err != nil && !errors.Is(err, drivers.ErrTableRecordNotFound) {
+	serviceID, err := getServiceIDByName(catalogID, cm.ConfigDeleteNamespaceItsmServiceName)
+	if err != nil {
 		return err
-	}
-	if err == nil {
-		imported = true
-	} else {
-		imported = false
 	}
 	// 自定义模板分隔符为 [[ ]]，例如 [[ .Name ]]，避免和 ITSM 模板变量格式冲突
 	tmpl, err := template.New("delete_shared_namespace.json.tpl").Delims("[[", "]]").
@@ -303,8 +286,8 @@ func importDeleteNamespaceService(catalogID uint32) error {
 	}
 	importReq := itsm.ImportServiceReq{
 		Key:             "request",
-		Name:            "删除共享集群命名空间",
-		Desc:            "删除共享集群命名空间",
+		Name:            cm.ConfigDeleteNamespaceItsmServiceName,
+		Desc:            cm.ConfigDeleteNamespaceItsmServiceName,
 		CatelogID:       catalogID,
 		Owners:          "admin",
 		CanTicketAgency: false,
@@ -315,21 +298,37 @@ func importDeleteNamespaceService(catalogID uint32) error {
 		ProjectKey:      "0",
 		Workflow:        mp,
 	}
-	var serviceID int
-	if !imported {
+
+	if serviceID == 0 {
+		logging.Info("service(name: %s) not found in itsm, creating", cm.ConfigDeleteNamespaceItsmServiceName)
 		serviceID, err = itsm.ImportService(importReq)
 		if err != nil {
 			return err
 		}
-		return model.SetConfig(context.Background(), cm.ConfigKeyDeleteNamespaceItsmServiceID,
-			strconv.Itoa(serviceID))
+	} else {
+		logging.Info("service(name: %s, id: %d) found in itsm, updating",
+			cm.ConfigDeleteNamespaceItsmServiceName, serviceID)
+		err = itsm.UpdateService(itsm.UpdateServiceReq{
+			ID:               serviceID,
+			ImportServiceReq: importReq,
+		})
+		if err != nil {
+			return err
+		}
 	}
-	serviceID, err = strconv.Atoi(serviceIDStr)
+	return model.SetConfig(context.Background(), cm.ConfigKeyDeleteNamespaceItsmServiceID,
+		strconv.Itoa(serviceID))
+}
+
+func getServiceIDByName(catalogID uint32, name string) (int, error) {
+	services, err := itsm.ListServices(catalogID)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	return itsm.UpdateService(itsm.UpdateServiceReq{
-		ID:               serviceID,
-		ImportServiceReq: importReq,
-	})
+	for _, service := range services {
+		if service.Name == name {
+			return service.ID, nil
+		}
+	}
+	return 0, nil
 }


### PR DESCRIPTION
当bcs进行重装时，可能会由于mongodb的重装导致原本的数据丢失，但是itsm服务上依旧保留了相关的service，再重装时执行itsm-migrate的job时就可能会出错，因为重复导入的service；同时也需要考虑另外一种情况，当itsm进行重装或者是数据初始化，导致数据丢失，造成两边数据不一致的问题。修改思路如下：

1. 首先查询itsm，如果可以查到相关的service，则拿到serviceID进行更新
2. 没查到则tism上无相关service，进行导入
3. 最后通过serviceID，更新mongodb。无论是导入或者更新都对mongodb进行更新保证数据一致