### PR TITLE
feat: cluster-resources支持自定义配置projectcode注解

### DIFF
--- a/bcs-services/cluster-resources/etc/conf.yaml
+++ b/bcs-services/cluster-resources/etc/conf.yaml
@@ -118,7 +118,7 @@ crGlobal:
   sharedCluster:
     enabledCObjKinds: []
     enabledCRDs: []
-
+    annotationKeyProjectCode: ""
   # TRACING 相关配置
 tracing:
   tracingEnabled: false

--- a/bcs-services/cluster-resources/pkg/common/conf/conf.go
+++ b/bcs-services/cluster-resources/pkg/common/conf/conf.go
@@ -22,6 +22,8 @@ const (
 	ProjectMgrServiceName = "project.bkbcs.tencent.com"
 	// ClusterMgrServiceName 集群管理服务名
 	ClusterMgrServiceName = "clustermanager.bkbcs.tencent.com"
+	// ProjectCodeAnnoKey 命名空间所属 projectcode 注解 key 的默认值
+	ProjectCodeAnnoKey = "io.tencent.bcs.projectcode"
 	// LangCookieName 语言版本 Cookie 名称
 	LangCookieName = "blueking_language"
 	// MaxGrpcMsgSize 单请求/响应体最大尺寸 64MB

--- a/bcs-services/cluster-resources/pkg/config/config.go
+++ b/bcs-services/cluster-resources/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
+	constant "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/envs"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/errcode"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/util/errorx"
@@ -64,6 +65,10 @@ func LoadConf(filePath string) (*ClusterResourcesConf, error) {
 	}
 	if conf.Global.IAM.Host == "" {
 		conf.Global.IAM.Host = envs.BKIAMHost
+	}
+
+	if conf.Global.SharedCluster.AnnotationKeyProjectCode == "" {
+		conf.Global.SharedCluster.AnnotationKeyProjectCode = constant.ProjectCodeAnnoKey
 	}
 
 	if conf.Redis.Password == "" {
@@ -343,8 +348,9 @@ type IAMConf struct {
 
 // SharedClusterConf 共享集群相关配置
 type SharedClusterConf struct {
-	EnabledCObjKinds []string `yaml:"enabledCObjKinds" usage:"共享集群中支持的自定义对象 Kind"`
-	EnabledCRDs      []string `yaml:"enabledCRDs" usage:"共享集群中支持的 CRD"` // nolint:tagliatelle
+	EnabledCObjKinds         []string `yaml:"enabledCObjKinds" usage:"共享集群中支持的自定义对象 Kind"`
+	EnabledCRDs              []string `yaml:"enabledCRDs" usage:"共享集群中支持的 CRD"` // nolint:tagliatelle
+	AnnotationKeyProjectCode string   `yaml:"annotationKeyProjectCode" usage:"共享集群ProjectCode注解的key"`
 }
 
 // MultiClusterConf 多集群相关配置

--- a/bcs-services/cluster-resources/pkg/handler/testing.go
+++ b/bcs-services/cluster-resources/pkg/handler/testing.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/action"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/cluster"
+	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/ctxkey"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/envs"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/component/project"
@@ -102,7 +103,8 @@ func GetOrCreateNS(namespace string) error {
 	if err != nil {
 		_ = mapx.SetItems(nsManifest4Test, "metadata.name", namespace)
 		if namespace == envs.TestSharedClusterNS {
-			_ = mapx.SetItems(nsManifest4Test, []string{"metadata", "annotations", cli.ProjCodeAnnoKey}, envs.TestProjectCode)
+			_ = mapx.SetItems(nsManifest4Test, []string{
+				"metadata", "annotations", conf.ProjectCodeAnnoKey}, envs.TestProjectCode)
 		}
 		_, err = nsCli.Create(ctx, nsManifest4Test, false, metav1.CreateOptions{})
 	}

--- a/bcs-services/cluster-resources/pkg/resource/client/ns.go
+++ b/bcs-services/cluster-resources/pkg/resource/client/ns.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/ctxkey"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/errcode"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/component/project"
+	conf "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/config"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/i18n"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/iam"
 	clusterAuth "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/iam/perm/resource/cluster"
@@ -31,11 +32,6 @@ import (
 	resCsts "github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/resource/constants"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/util/errorx"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/util/mapx"
-)
-
-const (
-	// ProjCodeAnnoKey 项目 Code 在命名空间 Annotations 中的 Key
-	ProjCodeAnnoKey = "io.tencent.bcs.projectcode"
 )
 
 // NSClient xxx
@@ -162,8 +158,11 @@ func filterProjNSList(ctx context.Context, manifest map[string]interface{}) (map
 func isProjNSinSharedCluster(manifest map[string]interface{}, projectCode string) bool {
 	// 规则：属于项目的命名空间满足以下两点，但这里只需要检查 annotations 即可
 	//   1. 命名(name) 以 ieg-{project_code}- 开头
-	//   2. annotations 中包含 io.tencent.bcs.projectcode: {project_code}
-	return mapx.GetStr(manifest, []string{"metadata", "annotations", ProjCodeAnnoKey}) == projectCode
+	//   2. annotations 中包含 {annotation_key_project_code}: {project_code}
+	//   3. {annotation_key_project_code} 默认值为 io.tencent.bcs.projectcode
+	return mapx.GetStr(manifest, []string{
+		"metadata", "annotations", conf.G.SharedCluster.AnnotationKeyProjectCode,
+	}) == projectCode
 }
 
 // NSWatcher xxx


### PR DESCRIPTION
目前共享集群中命名空间所属的项目都是通过 io.tencent.bcs.projectcode 这个注解来区分的，有场景的使用需求是这个注解的key是可配置的。

修改配置中增加了对该值的配置字段，在调用处替换为使用配置值。在初始化时为配置该字段则默认使用 io.tencent.bcs.projectcode，兼容原有配置。