### PR TITLE
feat: cluster-manager支持自定义配置projectcode注解

### DIFF
--- a/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
+++ b/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
@@ -194,6 +194,9 @@
         "enableInsTypeUsage": ${enableInsTypeUsage},
         "enableAllocateCidr": ${enableAllocateCidr}
     },
+    "sharedCluster": {
+      "annoKeyProjCode": "${bcsSharedClusterAnnoKeyProjCode}"
+    },
     "tagDepart": "${tagDepart}",
     "prefixVcluster": "${prefixVcluster}",
     "version": "${bcsClusterManagerVersion}",

--- a/bcs-services/bcs-cluster-manager/internal/actions/cluster/create_vcluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cluster/create_vcluster.go
@@ -186,11 +186,11 @@ func (ca *CreateVirtualClusterAction) validate() error {
 	}
 	if ca.req.Ns.Annotations == nil {
 		ca.req.Ns.Annotations = map[string]string{
-			utils.ProjectCode:      ca.req.ProjectCode,
+			options.GetGlobalCMOptions().SharedCluster.AnnoKeyProjCode: ca.req.ProjectCode,
 			utils.NamespaceCreator: ca.req.Creator,
 		}
 	} else {
-		ca.req.Ns.Annotations[utils.ProjectCode] = ca.req.ProjectCode
+		ca.req.Ns.Annotations[options.GetGlobalCMOptions().SharedCluster.AnnoKeyProjCode] = ca.req.ProjectCode
 		ca.req.Ns.Annotations[utils.NamespaceCreator] = ca.req.Creator
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/app/app.go
+++ b/bcs-services/bcs-cluster-manager/internal/app/app.go
@@ -866,6 +866,12 @@ func (cm *ClusterManager) initCommonHandler(router *mux.Router) error {
 	return nil
 }
 
+func (cm *ClusterManager) initSharedClusterConf() {
+	if cm.opt.SharedCluster.AnnoKeyProjCode == "" {
+		cm.opt.SharedCluster.AnnoKeyProjCode = utils.ProjectCode
+	}
+}
+
 // initHTTPService init http service
 func (cm *ClusterManager) initHTTPService() error {
 	router := mux.NewRouter()
@@ -1181,6 +1187,8 @@ func (cm *ClusterManager) Init() error {
 		blog.Errorf("initCloudTemplateConfig failed: %v", err)
 	}
 
+	// init shared cluster config
+	cm.initSharedClusterConf()
 	// init metric, pprof
 	cm.initExtraModules()
 	// init system signal handler

--- a/bcs-services/bcs-cluster-manager/internal/options/options.go
+++ b/bcs-services/bcs-cluster-manager/internal/options/options.go
@@ -292,6 +292,11 @@ type DaemonConfig struct {
 	EnableAllocateCidr bool `json:"enableAllocateCidr"`
 }
 
+// SharedClusterConfig config for shared cluster
+type SharedClusterConfig struct {
+	AnnoKeyProjCode string `json:"annoKeyProjCode"`
+}
+
 // ClusterManagerOptions options of cluster manager
 type ClusterManagerOptions struct {
 	Etcd               EtcdOption            `json:"etcd"`
@@ -326,6 +331,7 @@ type ClusterManagerOptions struct {
 	TracingConfig      conf.TracingConfig    `json:"tracingConfig"`
 	Encrypt            encryptv2.Config      `json:"encrypt"`
 	Daemon             DaemonConfig          `json:"daemon"`
+	SharedCluster      SharedClusterConfig   `json:"sharedCluster"`
 	ServerConfig
 	ClientConfig
 }

--- a/install/conf/bcs-services/bcs-cluster-manager/bcs-cluster-manager.json.template
+++ b/install/conf/bcs-services/bcs-cluster-manager/bcs-cluster-manager.json.template
@@ -193,6 +193,9 @@
         "enableInsTypeUsage": ${enableInsTypeUsage},
         "enableAllocateCidr": ${enableAllocateCidr}
     },
+    "sharedCluster": {
+      "annoKeyProjCode": "${bcsSharedClusterAnnoKeyProjCode}"
+    },
     "tagDepart": "${tagDepart}",
     "prefixVcluster": "${prefixVcluster}",
     "version": "${bcsClusterManagerVersion}",


### PR DESCRIPTION
目前共享集群中命名空间所属的项目都是通过 io.tencent.bcs.projectcode 这个注解来区分的，有场景的使用需求是这个注解的key是可配置的。

修改配置中增加了对该值的配置字段，在调用处替换为使用配置值。在初始化时为配置该字段则默认使用 io.tencent.bcs.projectcode，兼容原有配置。