### PR TITLE
feat: helm-manager支持自定义配置projectcode注解

### DIFF
--- a/bcs-services/bcs-helm-manager/internal/app/app.go
+++ b/bcs-services/bcs-helm-manager/internal/app/app.go
@@ -143,6 +143,7 @@ func (hm *HelmManager) Init() error {
 		hm.initRegistry,
 		hm.initJWTClient,
 		hm.initIAMClient,
+		hm.initSharedClusterConf,
 		hm.InitComponentConfig,
 		hm.initDiscovery,
 		hm.initMicro,
@@ -601,6 +602,14 @@ func (hm *HelmManager) initIAMClient() error {
 	auth.IAMClient = iamClient
 	auth.InitPermClient(iamClient)
 	blog.Info("init iam client successfully")
+	return nil
+}
+
+// initSharedClusterConf init conf value for shared cluster
+func (hm *HelmManager) initSharedClusterConf() error {
+	if hm.opt.SharedCluster.AnnotationKeyProjCode == "" {
+		hm.opt.SharedCluster.AnnotationKeyProjCode = common.AnnotationKeyProjectCode
+	}
 	return nil
 }
 

--- a/bcs-services/bcs-helm-manager/internal/auth/iam.go
+++ b/bcs-services/bcs-helm-manager/internal/auth/iam.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-helm-manager/internal/component"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-helm-manager/internal/options"
 )
 
 var (
@@ -37,9 +38,6 @@ var (
 	ClusterIamClient *cluster.BCSClusterPerm
 	// NamespaceIamClient namespace iam client
 	NamespaceIamClient *namespace.BCSNamespacePerm
-
-	// ProjCodeAnnoKey 项目 Code 在命名空间 Annotations 中的 Key
-	ProjCodeAnnoKey = "io.tencent.bcs.projectcode"
 )
 
 // InitPermClient new a perm client
@@ -105,7 +103,7 @@ func ReleaseResourcePermCheck(projectCode, clusterID string, namespaceCreated, c
 		if err != nil {
 			return false, "", nil, err
 		}
-		if ns.Annotations[ProjCodeAnnoKey] != projectCode {
+		if ns.Annotations[options.GlobalOptions.SharedCluster.AnnotationKeyProjCode] != projectCode {
 			return false, "", nil, fmt.Errorf("命名空间 %s 在该共享集群中不属于指定项目", v)
 		}
 	}

--- a/bcs-services/bcs-helm-manager/internal/common/constant.go
+++ b/bcs-services/bcs-helm-manager/internal/common/constant.go
@@ -51,3 +51,9 @@ const (
 	// LangCookieName 语言版本 Cookie 名称
 	LangCookieName = "blueking_language"
 )
+
+// shared cluster
+const (
+	// AnnotationKeyProjectCode namespace 的 projectcode 注解 key 默认值
+	AnnotationKeyProjectCode = "io.tencent.bcs.projectcode"
+)

--- a/bcs-services/bcs-helm-manager/internal/options/options.go
+++ b/bcs-services/bcs-helm-manager/internal/options/options.go
@@ -160,21 +160,27 @@ type EncryptSecret struct {
 	Secret string `json:"secret" yaml:"secret"`
 }
 
+// SharedClusterConfig options of shared cluster config
+type SharedClusterConfig struct {
+	AnnotationKeyProjCode string `json:"annotationKeyProjCode" yaml:"annotationKeyProjCode"`
+}
+
 // HelmManagerOptions options of helm manager
 type HelmManagerOptions struct {
-	Etcd          EtcdOption         `json:"etcd" yaml:"etcd"`
-	BcsLog        LogConfig          `json:"log" yaml:"log"`
-	Swagger       SwaggerConfig      `json:"swagger" yaml:"swagger"`
-	Mongo         MongoConfig        `json:"mongo" yaml:"mongo"`
-	Repo          RepoConfig         `json:"repo" yaml:"repo"`
-	Release       ReleaseConfig      `json:"release" yaml:"release"`
-	IAM           IAMConfig          `json:"iam" yaml:"iam"`
-	JWT           JWTConfig          `json:"jwt" yaml:"jwt"`
-	Credentials   []Credential       `json:"credentials" yaml:"credentials"`
-	Encrypt       Encrypt            `json:"encrypt" yaml:"encrypt"`
-	Debug         bool               `json:"debug" yaml:"debug"`
-	TLS           TLS                `json:"tls" yaml:"tls"`
-	TracingConfig conf.TracingConfig `json:"tracingConfig" yaml:"tracingConfig"`
+	Etcd          EtcdOption          `json:"etcd" yaml:"etcd"`
+	BcsLog        LogConfig           `json:"log" yaml:"log"`
+	Swagger       SwaggerConfig       `json:"swagger" yaml:"swagger"`
+	Mongo         MongoConfig         `json:"mongo" yaml:"mongo"`
+	Repo          RepoConfig          `json:"repo" yaml:"repo"`
+	Release       ReleaseConfig       `json:"release" yaml:"release"`
+	IAM           IAMConfig           `json:"iam" yaml:"iam"`
+	JWT           JWTConfig           `json:"jwt" yaml:"jwt"`
+	Credentials   []Credential        `json:"credentials" yaml:"credentials"`
+	Encrypt       Encrypt             `json:"encrypt" yaml:"encrypt"`
+	Debug         bool                `json:"debug" yaml:"debug"`
+	TLS           TLS                 `json:"tls" yaml:"tls"`
+	TracingConfig conf.TracingConfig  `json:"tracingConfig" yaml:"tracingConfig"`
+	SharedCluster SharedClusterConfig `json:"sharedCluster" yaml:"sharedCluster"`
 	ServerConfig
 }
 


### PR DESCRIPTION
目前共享集群中命名空间所属的项目都是通过 io.tencent.bcs.projectcode 这个注解来区分的，有场景的使用需求是这个注解的key是可配置的。

修改配置中增加了对该值的配置字段，在调用处替换为使用配置值。在初始化时为配置该字段则默认使用 io.tencent.bcs.projectcode，兼容原有配置。