### PR TITLE
feat: data-manager支持自定义配置projectcode注解

### DIFF
--- a/bcs-services/bcs-data-manager/cmd/options.go
+++ b/bcs-services/bcs-data-manager/cmd/options.go
@@ -118,29 +118,35 @@ type KafkaConfig struct {
 	Password  string `json:"password"`
 }
 
+// SharedClusterConfig options of shared cluster
+type SharedClusterConfig struct {
+	AnnoKeyProjCode string `json:"annoKeyProjCode"`
+}
+
 // DataManagerOptions options of data manager
 type DataManagerOptions struct {
 	conf.FileConfig
 	conf.LogConfig
 	ClientConfig
 	ServerConfig
-	Mongo                  MongoOption        `json:"mongoConf"`
-	BcsMonitorConf         BcsMonitorConfig   `json:"bcsMonitorConf"`
-	QueueConfig            QueueConfig        `json:"queueConfig"`
-	HandleConfig           HandleConfig       `json:"handleConfig"`
-	Etcd                   EtcdOption         `json:"etcd"`
-	BcsAPIConf             BcsAPIConfig       `json:"bcsApiConf"`
-	Debug                  bool               `json:"debug"`
-	FilterRules            ClusterFilterRules `json:"filterRules"`
-	AppCode                string             `json:"appCode"`
-	AppSecret              string             `json:"appSecret"`
-	ProducerConfig         ProducerConfig     `json:"producerConfig"`
-	KafkaConfig            KafkaConfig        `json:"kafkaConfig"`
-	NeedSendKafka          bool               `json:"needSendKafka"`
-	IgnoreBkMonitorCluster bool               `json:"ignoreBkMonitorCluster"`
-	QueryFromBkMonitor     bool               `json:"queryFromBkMonitor"`
-	BkbaseConfigPath       string             `json:"bkbaseConfigPath"`
-	TspiderConfigPath      string             `json:"tspiderConfigPath"`
+	Mongo                  MongoOption         `json:"mongoConf"`
+	BcsMonitorConf         BcsMonitorConfig    `json:"bcsMonitorConf"`
+	QueueConfig            QueueConfig         `json:"queueConfig"`
+	HandleConfig           HandleConfig        `json:"handleConfig"`
+	Etcd                   EtcdOption          `json:"etcd"`
+	BcsAPIConf             BcsAPIConfig        `json:"bcsApiConf"`
+	Debug                  bool                `json:"debug"`
+	FilterRules            ClusterFilterRules  `json:"filterRules"`
+	AppCode                string              `json:"appCode"`
+	AppSecret              string              `json:"appSecret"`
+	ProducerConfig         ProducerConfig      `json:"producerConfig"`
+	KafkaConfig            KafkaConfig         `json:"kafkaConfig"`
+	SharedClusterConfig    SharedClusterConfig `json:"sharedClusterConfig"`
+	NeedSendKafka          bool                `json:"needSendKafka"`
+	IgnoreBkMonitorCluster bool                `json:"ignoreBkMonitorCluster"`
+	QueryFromBkMonitor     bool                `json:"queryFromBkMonitor"`
+	BkbaseConfigPath       string              `json:"bkbaseConfigPath"`
+	TspiderConfigPath      string              `json:"tspiderConfigPath"`
 }
 
 // ClusterFilterRules rules for cluster filter

--- a/bcs-services/bcs-data-manager/cmd/server.go
+++ b/bcs-services/bcs-data-manager/cmd/server.go
@@ -124,6 +124,8 @@ func (s *Server) Init() error {
 		return err
 	}
 
+	// init shared cluster config
+	s.initSharedClusterConf()
 	// init metric, pprof
 	s.initExtraModules()
 	// init system signal handler
@@ -445,7 +447,7 @@ func (s *Server) initWorker() error {
 	}
 	// init resourceGetter
 	s.resourceGetter = common.NewGetter(s.opt.FilterRules.NeedFilter, selectClusters, s.opt.FilterRules.Env,
-		pmClient, bcsMonitorCli)
+		s.opt.SharedClusterConfig.AnnoKeyProjCode, pmClient, bcsMonitorCli)
 	// init producer
 	producerCron := cron.New()
 	s.producer = worker.NewProducer(s.ctx, msgQueue, producerCron, cmCli, k8sStorageCli, mesosStorageCli,
@@ -654,6 +656,13 @@ func (s *Server) initStorageCli() (bcsapi.Storage, bcsapi.Storage, error) {
 	}
 	blog.Infof("init mesos storage cli success")
 	return k8sStorageCli, mesosStorageCli, nil
+}
+
+// initSharedClusterConf init shared cluster config
+func (s *Server) initSharedClusterConf() {
+	if s.opt.SharedClusterConfig.AnnoKeyProjCode == "" {
+		s.opt.SharedClusterConfig.AnnoKeyProjCode = types.AnnotationKeyProjectCode
+	}
 }
 
 // initExtraModules xxx

--- a/bcs-services/bcs-data-manager/image/bcs-data-manager.json.template
+++ b/bcs-services/bcs-data-manager/image/bcs-data-manager.json.template
@@ -70,6 +70,9 @@
       "username": "${kafkaUsername}",
       "password": "${kafkaPassword}"
   },
+  "sharedClusterConfig": {
+      "annoKeyProjCode": "${sharedClusterAnnoKeyProjCode}"
+  }
   "bkbaseConfigPath": "${bkbaseConfigPath}",
   "tspiderConfigPath": "${tspiderConfigPath}"
 }

--- a/bcs-services/bcs-data-manager/pkg/common/common.go
+++ b/bcs-services/bcs-data-manager/pkg/common/common.go
@@ -60,28 +60,30 @@ type GetterInterface interface {
 
 // ResourceGetter common resource getter
 type ResourceGetter struct {
-	needFilter     bool
-	clusterIDs     map[string]bool
-	env            string
-	cache          *cache.Cache
-	projectManager bcsproject.BcsProjectManagerClient
-	bcsMonitorCli  bcsmonitor.ClientInterface
+	needFilter      bool
+	clusterIDs      map[string]bool
+	env             string
+	cache           *cache.Cache
+	projectManager  bcsproject.BcsProjectManagerClient
+	bcsMonitorCli   bcsmonitor.ClientInterface
+	AnnoKeyProjCode string
 }
 
 // NewGetter new common resource getter
-func NewGetter(needFilter bool, clusterIds []string, env string,
+func NewGetter(needFilter bool, clusterIds []string, env string, annoKeyProjCode string,
 	pmClient bcsproject.BcsProjectManagerClient, bcsMonitorCli bcsmonitor.ClientInterface) GetterInterface {
 	clusterMap := make(map[string]bool, len(clusterIds))
 	for index := range clusterIds {
 		clusterMap[clusterIds[index]] = true
 	}
 	return &ResourceGetter{
-		needFilter:     needFilter,
-		clusterIDs:     clusterMap,
-		env:            env,
-		cache:          cache.New(time.Minute*10, time.Minute*60),
-		projectManager: pmClient,
-		bcsMonitorCli:  bcsMonitorCli,
+		needFilter:      needFilter,
+		clusterIDs:      clusterMap,
+		env:             env,
+		cache:           cache.New(time.Minute*10, time.Minute*60),
+		projectManager:  pmClient,
+		bcsMonitorCli:   bcsMonitorCli,
+		AnnoKeyProjCode: annoKeyProjCode,
 	}
 }
 
@@ -449,7 +451,7 @@ func (g *ResourceGetter) GetK8sNamespaceList(ctx context.Context, clusterMeta *t
 	for _, namespace := range namespaces {
 		if clusterLabel != nil && clusterLabel["isShared"] == "true" {
 			nsAnnotation := namespace.Data.Annotations
-			if projectCode, ok := nsAnnotation["io.tencent.bcs.projectcode"]; ok {
+			if projectCode, ok := nsAnnotation[g.AnnoKeyProjCode]; ok {
 				namespaceProjectCode = projectCode
 				project, err := g.GetProjectInfo(ctx, "", namespaceProjectCode, pmCli)
 				if err != nil {

--- a/bcs-services/bcs-data-manager/pkg/types/types.go
+++ b/bcs-services/bcs-data-manager/pkg/types/types.go
@@ -106,6 +106,12 @@ const (
 	SecondTimeFormat = "2006-01-02 15:04:05"
 )
 
+// Shared cluster
+const (
+	// AnnotationKeyProjectCode default project code annotation key
+	AnnotationKeyProjectCode = "io.tencent.bcs.projectcode"
+)
+
 // ProjectMeta meta for project
 type ProjectMeta struct {
 	ProjectID   string            `json:"projectID"`


### PR DESCRIPTION
目前共享集群中命名空间所属的项目都是通过 io.tencent.bcs.projectcode 这个注解来区分的，有场景的使用需求是这个注解的key是可配置的。

修改配置中增加了对该值的配置字段，在调用处替换为使用配置值。在初始化时为配置该字段则默认使用 io.tencent.bcs.projectcode，兼容原有配置。