### PR TITLE
feat: bcs-common mongodb client支持配置replicaset

### DIFF
--- a/bcs-common/pkg/odm/drivers/mongo/mongo.go
+++ b/bcs-common/pkg/odm/drivers/mongo/mongo.go
@@ -40,6 +40,7 @@ type Options struct {
 	MaxPoolSize           uint64
 	MinPoolSize           uint64
 	Hosts                 []string
+	Replicaset            string
 	Monitor               *event.CommandMonitor
 }
 
@@ -66,6 +67,9 @@ func NewDB(opt *Options) (*DB, error) {
 		Auth:    &credential,
 		Hosts:   opt.Hosts,
 		Monitor: opt.Monitor,
+	}
+	if opt.Replicaset != "" {
+		mCliOpt.ReplicaSet = &opt.Replicaset
 	}
 	if opt.MaxPoolSize != 0 {
 		mCliOpt.MaxPoolSize = &opt.MaxPoolSize


### PR DESCRIPTION
当前，bcs 代码层面不支持配置副本集名称。在连接副本集模式下的 MongoDB 时，若副本集名称为默认的 `rs0`，连接正常；但当副本集名称为其他值时，连接会出现异常，报认证失败的错误。

其他服务都依赖bcs-common下的mongodb client，需要先在client支持配置。

修改如下：
- `bcs-common/pkg/odm/drivers/mongo/mongo.go`
  - 在 `Options` 中增加 `ReplicaSet` 字段。
  - 在 `bcs-common` 中的 `NewDB` 函数中，增加兼容性处理。当 `Replicaset` 字段为空字符串时，客户端在创建时不指定 `replicaset`，与原先未配置 `replicaset` 字段时的行为保持一致，这样可以确保，在最小改动各个模块代码的同时，现有配置不会受到影响。

  ```go
  if opt.ReplicaSet != "" {
      mCliOpt.ReplicaSet = &opt.ReplicaSet
  }
  ```