### PR TITLE
feat: cluster-manager 支持mongodb配置replicaset

### DIFF
--- a/bcs-common/pkg/odm/drivers/mongo/mongo.go
+++ b/bcs-common/pkg/odm/drivers/mongo/mongo.go
@@ -40,6 +40,7 @@ type Options struct {
 	MaxPoolSize           uint64
 	MinPoolSize           uint64
 	Hosts                 []string
+	Replicaset            string
 	Monitor               *event.CommandMonitor
 }
 
@@ -66,6 +67,9 @@ func NewDB(opt *Options) (*DB, error) {
 		Auth:    &credential,
 		Hosts:   opt.Hosts,
 		Monitor: opt.Monitor,
+	}
+	if opt.Replicaset != "" {
+		mCliOpt.ReplicaSet = &opt.Replicaset
 	}
 	if opt.MaxPoolSize != 0 {
 		mCliOpt.MaxPoolSize = &opt.MaxPoolSize

--- a/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
+++ b/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
@@ -1,6 +1,7 @@
 {
     "mongo": {
         "address": "${bcsClusterManagerMongoAddress}",
+        "replicaset": "${bcsClusterManagerMongoReplicaset}"
         "connecttimeout": ${bcsClusterManagerMongoConnectTimeout},
         "database": "${bcsClusterManagerMongoDatabase}",
         "username": "${bcsClusterManagerMongoUsername}",

--- a/bcs-services/bcs-cluster-manager/go.mod
+++ b/bcs-services/bcs-cluster-manager/go.mod
@@ -3,6 +3,7 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager
 go 1.20
 
 replace (
+	github.com/Tencent/bk-bcs/bcs-common => ../../bcs-common
 	k8s.io/api => k8s.io/api v0.26.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.26.1

--- a/bcs-services/bcs-cluster-manager/internal/app/app.go
+++ b/bcs-services/bcs-cluster-manager/internal/app/app.go
@@ -263,6 +263,7 @@ func (cm *ClusterManager) initModel() error {
 	password := cm.opt.Mongo.Password
 	mongoOptions := &mongo.Options{
 		Hosts:                 strings.Split(cm.opt.Mongo.Address, ","),
+		Replicaset:            cm.opt.Mongo.Replicaset,
 		ConnectTimeoutSeconds: int(cm.opt.Mongo.ConnectTimeout),
 		Database:              cm.opt.Mongo.Database,
 		Username:              cm.opt.Mongo.Username,

--- a/bcs-services/bcs-cluster-manager/internal/options/options.go
+++ b/bcs-services/bcs-cluster-manager/internal/options/options.go
@@ -74,6 +74,7 @@ type TunnelConfig struct {
 // MongoConfig option for mongo
 type MongoConfig struct {
 	Address        string `json:"address"`
+	Replicaset     string `json:"replicaset"`
 	ConnectTimeout uint   `json:"connecttimeout"`
 	Database       string `json:"database"`
 	Username       string `json:"username"`

--- a/bcs-services/bcs-cluster-manager/main.go
+++ b/bcs-services/bcs-cluster-manager/main.go
@@ -69,6 +69,7 @@ func main() { // nolint
 	flag.String("bcslog_backtraceat", "", "when logging hits line file:N, emit a stack trace")
 	// mongo config
 	flag.String("mongo_address", "127.0.0.1:27017", "mongo server address")
+	flag.String("mongo_replicaset", "", "mongo replica set name")
 	flag.Uint("mongo_connecttimeout", 3, "mongo server connnect timeout")
 	flag.String("mongo_database", "", "database in mongo for cluster manager")
 	flag.String("mongo_username", "", "mongo username for cluster manager")

--- a/install/conf/bcs-services/bcs-cluster-manager/bcs-cluster-manager.json.template
+++ b/install/conf/bcs-services/bcs-cluster-manager/bcs-cluster-manager.json.template
@@ -1,6 +1,7 @@
 {
     "mongo": {
         "address": "${bcsClusterManagerMongoAddress}",
+        "replicaset": "${bcsClusterManagerMongoReplicaset}",
         "connecttimeout": ${bcsClusterManagerMongoConnectTimeout},
         "database": "${bcsClusterManagerMongoDatabase}",
         "username": "${bcsClusterManagerMongoUsername}",


### PR DESCRIPTION
go.mod 中修改了 bcs-common 依赖为本地的，后续bcs-common的修改合入之后需要修改，去掉 `github.com/Tencent/bk-bcs/bcs-common => ../../bcs-common`

cluster-manager的修改如下：
- `bcs-services/bcs-cluster-manager/main.go`
  - 在 `main` 函数中增加 `flag.String("mongo_replicaset", xxx)` 配置项。
- `bcs-services/bcs-cluster-manager/internal/options/options.go`
  - 在 `MongoConfig` 结构体中增加 `ReplicaSet` 字段。
- `bcs-services/bcs-cluster-manager/internal/app/app.go`
  - 在 `initModel` 函数中，`mongo.Options` 增加 `ReplicaSet` 配置。
- `install/conf/bcs-services/bcs-cluster-manager/bcs-cluster-manager.json.template`
  - 在 MongoDB 配置中增加 `"replicaSet": "${bcsClusterManagerMongoReplicaSet}"`
