### PR TITLE
feat: cluster-manager 支持mongodb配置replicaset(v1.29.x)

### DIFF
--- a/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
+++ b/bcs-services/bcs-cluster-manager/conf/bcs-cluster-manager.json.template
@@ -1,6 +1,7 @@
 {
     "mongo": {
         "address": "${bcsClusterManagerMongoAddress}",
+        "replicaset": "${bcsClusterManagerMongoReplicaset}",
         "connecttimeout": ${bcsClusterManagerMongoConnectTimeout},
         "database": "${bcsClusterManagerMongoDatabase}",
         "username": "${bcsClusterManagerMongoUsername}",

--- a/bcs-services/bcs-cluster-manager/go.mod
+++ b/bcs-services/bcs-cluster-manager/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/RichardKnop/machinery/v2 v2.0.11
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20240418123107-72b120390195
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20241212064043-5cca411636d5
 	github.com/Tencent/bk-bcs/bcs-common/common/encryptv2 v0.0.0-20230908045126-c9d09981a9c5
 	github.com/Tencent/bk-bcs/bcs-services/pkg v0.0.0-20240418123107-72b120390195
 	github.com/apparentlymart/go-cidr v1.1.0

--- a/bcs-services/bcs-cluster-manager/internal/app/app.go
+++ b/bcs-services/bcs-cluster-manager/internal/app/app.go
@@ -240,6 +240,7 @@ func (cm *ClusterManager) initModel() error {
 	password := cm.opt.Mongo.Password
 	mongoOptions := &mongo.Options{
 		Hosts:                 strings.Split(cm.opt.Mongo.Address, ","),
+		Replicaset:            cm.opt.Mongo.Replicaset,
 		ConnectTimeoutSeconds: int(cm.opt.Mongo.ConnectTimeout),
 		Database:              cm.opt.Mongo.Database,
 		Username:              cm.opt.Mongo.Username,

--- a/bcs-services/bcs-cluster-manager/internal/options/options.go
+++ b/bcs-services/bcs-cluster-manager/internal/options/options.go
@@ -73,6 +73,7 @@ type TunnelConfig struct {
 // MongoConfig option for mongo
 type MongoConfig struct {
 	Address        string `json:"address"`
+	Replicaset     string `json:"replicaset"`
 	ConnectTimeout uint   `json:"connecttimeout"`
 	Database       string `json:"database"`
 	Username       string `json:"username"`

--- a/bcs-services/bcs-cluster-manager/main.go
+++ b/bcs-services/bcs-cluster-manager/main.go
@@ -66,6 +66,7 @@ func main() { // nolint
 	flag.String("bcslog_backtraceat", "", "when logging hits line file:N, emit a stack trace")
 	// mongo config
 	flag.String("mongo_address", "127.0.0.1:27017", "mongo server address")
+	flag.String("mongo_replicaset", "", "mongo replica set name")
 	flag.Uint("mongo_connecttimeout", 3, "mongo server connnect timeout")
 	flag.String("mongo_database", "", "database in mongo for cluster manager")
 	flag.String("mongo_username", "", "mongo username for cluster manager")

--- a/install/conf/bcs-services/bcs-cluster-manager/bcs-cluster-manager.json.template
+++ b/install/conf/bcs-services/bcs-cluster-manager/bcs-cluster-manager.json.template
@@ -1,6 +1,7 @@
 {
     "mongo": {
         "address": "${bcsClusterManagerMongoAddress}",
+        "replicaset": "${bcsClusterManagerMongoReplicaset}",
         "connecttimeout": ${bcsClusterManagerMongoConnectTimeout},
         "database": "${bcsClusterManagerMongoDatabase}",
         "username": "${bcsClusterManagerMongoUsername}",


### PR DESCRIPTION
feat: cluster-manager 支持mongodb配置replicaset(v1.29.x)

需要等待common合入之后，修改go.mod文件