### PR TITLE
feat: cluster-resources支持配置mongodb副本集名称

### DIFF
--- a/bcs-services/cluster-resources/cmd/init.go
+++ b/bcs-services/cluster-resources/cmd/init.go
@@ -491,6 +491,7 @@ func (crSvc *clusterResourcesService) initModel() error {
 	// init mongo options
 	mongoOptions := &mongo.Options{
 		Hosts:                 strings.Split(crSvc.conf.Mongo.Address, ","),
+		Replicaset:            crSvc.conf.Mongo.Replicaset,
 		ConnectTimeoutSeconds: int(crSvc.conf.Mongo.ConnectTimeout),
 		AuthDatabase:          crSvc.conf.Mongo.AuthDatabase,
 		Database:              crSvc.conf.Mongo.Database,

--- a/bcs-services/cluster-resources/go.mod
+++ b/bcs-services/cluster-resources/go.mod
@@ -40,7 +40,7 @@ replace (
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20241015035856-99f8d8f45458
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20241212023042-2c0651f4eded
 	github.com/TencentBlueKing/gopkg v1.1.0
 	github.com/TencentBlueKing/iam-go-sdk v0.1.6
 	// fork 自 https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/k8s.io/client-go/splunkclient-go

--- a/bcs-services/cluster-resources/pkg/common/envs/envs.go
+++ b/bcs-services/cluster-resources/pkg/common/envs/envs.go
@@ -52,6 +52,7 @@ var (
 	BKIAMSystemID    = envx.Get("BK_IAM_SYSTEM_ID", "")
 	RedisPassword    = envx.Get("REDIS_PASSWORD", "")
 	MongoAddress     = envx.Get("MONGO_ADDRESS", "")
+	MongoReplicaset  = envx.Get("MONGO_REPLICASET", "")
 	MongoUsername    = envx.Get("MONGO_USERNAME", "")
 	MongoPassword    = envx.Get("MONGO_PASSWORD", "")
 )

--- a/bcs-services/cluster-resources/pkg/config/config.go
+++ b/bcs-services/cluster-resources/pkg/config/config.go
@@ -74,6 +74,9 @@ func LoadConf(filePath string) (*ClusterResourcesConf, error) {
 	if conf.Mongo.Address == "" {
 		conf.Mongo.Address = envs.MongoAddress
 	}
+	if conf.Mongo.Replicaset == "" {
+		conf.Mongo.Replicaset = envs.MongoReplicaset
+	}
 	if conf.Mongo.Username == "" {
 		conf.Mongo.Username = envs.MongoUsername
 	}
@@ -283,6 +286,7 @@ type RedisConf struct {
 // MongoConfig option for mongo
 type MongoConfig struct {
 	Address        string `json:"address" yaml:"address"`
+	Replicaset     string `json:"replicaset" yaml:"replicaset"`
 	ConnectTimeout uint   `json:"connectTimeout" yaml:"connectTimeout"`
 	AuthDatabase   string `json:"authDatabase" yaml:"authDatabase"`
 	Database       string `json:"database" yaml:"database"`


### PR DESCRIPTION
修改如下：
1. go.mod文件更新依赖的bcs-common
2. 在Mongodb配置文件中增加了Replicaset字段
3. 增加读取环境变量MONGO_REPLICASET，不传入对原配置无影响