### PR TITLE
feat: project-manager支持配置mongodb副本集名称

### DIFF
--- a/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
+++ b/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
@@ -17,6 +17,7 @@ etcd:
   ca: ""
 mongo:
   address: "127.0.0.1:27017"
+  replicaset: ""
   connecttimeout: 5
   database: "bcsproject_project"
   username: "admin"

--- a/bcs-services/bcs-project-manager/go.mod
+++ b/bcs-services/bcs-project-manager/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20240803071244-414878b26fa9
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20241212023042-2c0651f4eded
 	github.com/Tencent/bk-bcs/bcs-common/common/task v0.0.0-20240619071101-df2f4bc5060b
 	github.com/Tencent/bk-bcs/bcs-services/pkg v0.0.0-20240418123107-72b120390195
 	github.com/TencentBlueKing/iam-go-sdk v0.1.6

--- a/bcs-services/bcs-project-manager/internal/config/config.go
+++ b/bcs-services/bcs-project-manager/internal/config/config.go
@@ -34,6 +34,7 @@ type EtcdConfig struct {
 // MongoConfig mongo db config
 type MongoConfig struct {
 	Address        string `yaml:"address"`
+	Replicaset     string `yaml:"replicaset"`
 	ConnectTimeout uint   `yaml:"connecttimeout"`
 	Database       string `yaml:"database"`
 	Username       string `yaml:"username"`

--- a/bcs-services/bcs-project-manager/internal/provider/manager/register.go
+++ b/bcs-services/bcs-project-manager/internal/provider/manager/register.go
@@ -56,6 +56,7 @@ func RunTaskManager() (*task.TaskManager, error) {
 		},
 		Backend: &bcsmongo.Options{
 			Hosts:                 strings.Split(config.GlobalConf.Mongo.Address, ","),
+			Replicaset:            config.GlobalConf.Mongo.Replicaset,
 			ConnectTimeoutSeconds: int(config.GlobalConf.Mongo.ConnectTimeout),
 			Database:              config.GlobalConf.Mongo.Database,
 			Username:              config.GlobalConf.Mongo.Username,

--- a/bcs-services/bcs-project-manager/internal/store/init.go
+++ b/bcs-services/bcs-project-manager/internal/store/init.go
@@ -53,6 +53,7 @@ func NewMongo(conf *config.MongoConfig) *mongo.DB {
 
 	mongoOptions := &mongo.Options{
 		Hosts:                 strings.Split(conf.Address, ","),
+		Replicaset:            conf.Replicaset,
 		ConnectTimeoutSeconds: int(conf.ConnectTimeout),
 		Database:              conf.Database,
 		Username:              conf.Username,

--- a/bcs-services/bcs-project-manager/script/migrations/itsm/migrate.go
+++ b/bcs-services/bcs-project-manager/script/migrations/itsm/migrate.go
@@ -57,6 +57,7 @@ func initDB() error {
 	// mongo
 	store.InitMongo(&config.MongoConfig{
 		Address:        config.GlobalConf.Mongo.Address,
+		Replicaset:     config.GlobalConf.Mongo.Replicaset,
 		ConnectTimeout: config.GlobalConf.Mongo.ConnectTimeout,
 		Database:       config.GlobalConf.Mongo.Database,
 		Username:       config.GlobalConf.Mongo.Username,

--- a/bcs-services/bcs-project-manager/script/migrations/project/migrate.go
+++ b/bcs-services/bcs-project-manager/script/migrations/project/migrate.go
@@ -45,17 +45,18 @@ const (
 )
 
 var (
-	mysqlHost   string
-	mysqlPort   uint
-	mysqlUser   string
-	mysqlPwd    string
-	mysqlDBName string
-	mongoAddr   string
-	mongoUser   string
-	mongoPwd    string
-	mongoDBName string
-	initProject bool
-	migrateCC   bool
+	mysqlHost       string
+	mysqlPort       uint
+	mysqlUser       string
+	mysqlPwd        string
+	mysqlDBName     string
+	mongoAddr       string
+	mongoReplicaset string
+	mongoUser       string
+	mongoPwd        string
+	mongoDBName     string
+	initProject     bool
+	migrateCC       bool
 
 	ccdb  *gorm.DB
 	model store.ProjectModel
@@ -122,6 +123,7 @@ func parseFlags() {
 
 	// mongo
 	flag.StringVar(&mongoAddr, "mongo_addr", "", "mongo address")
+	flag.StringVar(&mongoReplicaset, "mongo_replicaset", "", "mongo replicaset")
 	flag.StringVar(&mongoUser, "mongo_user", "", "access mongo username")
 	flag.StringVar(&mongoPwd, "mongo_pwd", "", "access mongo password")
 	flag.StringVar(&mongoDBName, "mongo_db_name", "", "access mongo db name")
@@ -138,6 +140,7 @@ func initDB() error {
 	// mongo
 	store.InitMongo(&config.MongoConfig{
 		Address:        mongoAddr,
+		Replicaset:     mongoReplicaset,
 		ConnectTimeout: 5,
 		Database:       mongoDBName,
 		Username:       mongoUser,

--- a/bcs-services/bcs-project-manager/script/migrations/variable/migrate.go
+++ b/bcs-services/bcs-project-manager/script/migrations/variable/migrate.go
@@ -60,10 +60,11 @@ var (
 	ccDBName string
 
 	// bcs mongodb config
-	mongoAddr   string
-	mongoUser   string
-	mongoPwd    string
-	mongoDBName string
+	mongoAddr       string
+	mongoReplicaset string
+	mongoUser       string
+	mongoPwd        string
+	mongoDBName     string
 
 	// db instance
 	ccDB   *gorm.DB
@@ -88,6 +89,7 @@ func parseFlags() {
 
 	// mongo for bcs-project-manager
 	flag.StringVar(&mongoAddr, "mongo_addr", "", "mongo address")
+	flag.StringVar(&mongoReplicaset, "mongo_replicaset", "", "mongo replicaset")
 	flag.StringVar(&mongoUser, "mongo_user", "", "access mongo username")
 	flag.StringVar(&mongoPwd, "mongo_pwd", "", "access mongo password")
 	flag.StringVar(&mongoDBName, "mongo_db_name", "", "access mongo db name")


### PR DESCRIPTION
修改如下：
1. go.mod修改bcs-common版本
2. MongoConfig增加Replicaset字段
3. Mongodb的初始化包括init，register以及migrate等都增加了传入Replicaset