### PR TITLE
feat: helm-manager支持配置mongodb副本集名称(v1.29.x)

### DIFF
--- a/bcs-services/bcs-helm-manager/cmd/bcs-helm-manager-migrator/main.go
+++ b/bcs-services/bcs-helm-manager/cmd/bcs-helm-manager-migrator/main.go
@@ -103,6 +103,7 @@ func main() {
 	// init mongo options
 	mongoOptions := &mongo.Options{
 		Hosts:                 strings.Split(C.Mongo.Address, ","),
+		Replicaset:            C.Mongo.Replicaset,
 		ConnectTimeoutSeconds: int(C.Mongo.ConnectTimeout),
 		AuthDatabase:          C.Mongo.AuthDatabase,
 		Database:              C.Mongo.Database,

--- a/bcs-services/bcs-helm-manager/go.mod
+++ b/bcs-services/bcs-helm-manager/go.mod
@@ -12,7 +12,7 @@ replace (
 )
 
 require (
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20240418123107-72b120390195
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20241213022113-d2cc3e32d60c
 	github.com/Tencent/bk-bcs/bcs-common/common/encryptv2 v0.0.0-20230911112816-85f490b1c029
 	github.com/Tencent/bk-bcs/bcs-services/pkg v0.0.0-20240418123107-72b120390195
 	github.com/chartmuseum/helm-push v0.10.4

--- a/bcs-services/bcs-helm-manager/internal/app/app.go
+++ b/bcs-services/bcs-helm-manager/internal/app/app.go
@@ -217,6 +217,7 @@ func (hm *HelmManager) initModel() error {
 	}
 	mongoOptions := &mongo.Options{
 		Hosts:                 strings.Split(hm.opt.Mongo.Address, ","),
+		Replicaset:            hm.opt.Mongo.Replicaset,
 		ConnectTimeoutSeconds: int(hm.opt.Mongo.ConnectTimeout),
 		AuthDatabase:          hm.opt.Mongo.AuthDatabase,
 		Database:              hm.opt.Mongo.Database,

--- a/bcs-services/bcs-helm-manager/internal/options/options.go
+++ b/bcs-services/bcs-helm-manager/internal/options/options.go
@@ -53,6 +53,7 @@ type ServerConfig struct {
 // MongoConfig option for mongo
 type MongoConfig struct {
 	Address        string `json:"address" yaml:"address"`
+	Replicaset     string `json:"replicaset" yaml:"replicaset"`
 	ConnectTimeout uint   `json:"connectTimeout" yaml:"connectTimeout"`
 	AuthDatabase   string `json:"authDatabase" yaml:"authDatabase"`
 	Database       string `json:"database" yaml:"database"`


### PR DESCRIPTION
go.mod 修改了bcs-common的版本，其他修改按照合入主分支的方式修改。 已测过，可以正常连接且对原配置无影响