### PR TITLE
feat: bcs-storage支持配置mongodb副本集名称

### DIFF
--- a/bcs-services/bcs-storage/app/options/options.go
+++ b/bcs-services/bcs-storage/app/options/options.go
@@ -16,7 +16,7 @@ package options
 import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-common/common/static"
-	"github.com/Tencent/bk-bcs/bcs-common/pkg/registryv4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/registry"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/tracing"
 )
 
@@ -47,8 +47,8 @@ type StorageOptions struct {
 
 	ServerCert *CertConfig
 	ClientCert *CertConfig
-	Etcd       registryv4.CMDOptions `json:"etcdRegistry"`
-	Tracing    tracing.Options       `json:"tracing"`
+	Etcd       registry.CMDOptions `json:"etcdRegistry"`
+	Tracing    tracing.Options     `json:"tracing"`
 
 	DBConfig               string `json:"database_config_file" value:"storage-database.conf" usage:"Config file for database."`
 	QueueConfig            string `json:"queue_config_file" value:"queue.conf" usage:"Config file for database."`
@@ -75,6 +75,6 @@ func NewStorageOptions() *StorageOptions {
 			CertPwd: static.ClientCertPwd,
 			IsSSL:   false,
 		},
-		Etcd: registryv4.CMDOptions{},
+		Etcd: registry.CMDOptions{},
 	}
 }

--- a/bcs-services/bcs-storage/go.mod
+++ b/bcs-services/bcs-storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/Tencent/bk-bcs/bcs-services/bcs-storage
 
-go 1.17
+go 1.20
 
 replace (
 	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 => github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 v0.0.0-20210517125505-0f40c4b365cb
@@ -12,87 +12,87 @@ replace (
 )
 
 require (
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20230519085527-b0ca9cb924c7
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20241212023042-2c0651f4eded
 	github.com/deckarep/golang-set v1.8.0
 	github.com/emicklei/go-restful v2.15.0+incompatible
-	github.com/google/uuid v1.3.0
+	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opentracing/opentracing-go v1.2.0
-	github.com/prometheus/client_golang v1.12.1
+	github.com/prometheus/client_golang v1.19.0
 	go.mongodb.org/mongo-driver v1.9.0
-	golang.org/x/net v0.0.0-20220909164309-bea034e7d591
+	golang.org/x/net v0.23.0
 )
 
 require (
 	github.com/go-micro/plugins/v4/registry/etcd v1.1.0
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.4-0.20220905045406-6efdab108825
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	go-micro.dev/v4 v4.8.1
 	go.etcd.io/etcd/client/v3 v3.5.4 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect
-	google.golang.org/genproto v0.0.0-20220902135211-223410557253
-	google.golang.org/grpc v1.49.0
-	google.golang.org/protobuf v1.28.1
+	google.golang.org/grpc v1.62.1
+	google.golang.org/protobuf v1.33.0
 )
 
 require (
-	github.com/envoyproxy/protoc-gen-validate v0.1.0
+	github.com/envoyproxy/protoc-gen-validate v1.0.4
 	github.com/go-micro/plugins/v4/client/grpc v1.1.0
 	github.com/go-micro/plugins/v4/server/grpc v1.1.1
-	github.com/golang/protobuf v1.5.2
+	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/pkg/errors v0.9.1
+	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237
 )
 
 require (
-	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895 // indirect
+	dario.cat/mergo v1.0.0 // indirect
+	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 // indirect
-	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitly/go-simplejson v0.5.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/cloudflare/circl v1.2.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/emicklei/go-restful-openapi v1.4.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.5.0 // indirect
-	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-acme/lego/v4 v4.4.0 // indirect
-	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
+	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
+	github.com/go-git/go-billy/v5 v5.5.0 // indirect
+	github.com/go-git/go-git/v5 v5.12.0 // indirect
 	github.com/go-micro/plugins/v4/broker/rabbitmq v1.1.0 // indirect
 	github.com/go-micro/plugins/v4/broker/stan v1.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
-	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/spec v0.19.3 // indirect
-	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.0.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
-	github.com/klauspost/compress v1.13.6 // indirect
-	github.com/mailru/easyjson v0.7.0 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/miekg/dns v1.1.50 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -103,35 +103,38 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.32.1 // indirect
-	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.48.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/samuel/go-zookeeper v0.0.0-20201211165307-7117e9ea2414 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
+	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/streadway/amqp v1.0.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/uber/jaeger-client-go v2.29.1+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
-	github.com/ugorji/go/codec v1.2.3 // indirect
+	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/urfave/cli/v2 v2.14.1 // indirect
-	github.com/xanzy/ssh-agent v0.3.2 // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/scram v1.0.2 // indirect
-	github.com/xdg-go/stringprep v1.0.2 // indirect
+	github.com/xdg-go/scram v1.1.1 // indirect
+	github.com/xdg-go/stringprep v1.0.3 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.4 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.4 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
-	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sync v0.0.0-20220907140024-f12130a52804 // indirect
-	golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2 // indirect
-	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/tools v0.1.12 // indirect
+	golang.org/x/crypto v0.21.0 // indirect
+	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/sync v0.6.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/tools v0.13.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/bcs-services/bcs-storage/storage/actions/v1http/dynamic/queue_operate.go
+++ b/bcs-services/bcs-storage/storage/actions/v1http/dynamic/queue_operate.go
@@ -15,7 +15,7 @@ package dynamic
 
 import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
-	msgqueue "github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueuev4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueue"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/operator"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-storage/storage/apiserver"

--- a/bcs-services/bcs-storage/storage/actions/v1http/dynamic/utils.go
+++ b/bcs-services/bcs-storage/storage/actions/v1http/dynamic/utils.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	"github.com/Tencent/bk-bcs/bcs-common/common/codec"
 	"github.com/Tencent/bk-bcs/bcs-common/common/types"
-	msgqueue "github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueuev4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueue"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/drivers"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/operator"
 	"github.com/emicklei/go-restful"

--- a/bcs-services/bcs-storage/storage/actions/v1http/events/db_operate.go
+++ b/bcs-services/bcs-storage/storage/actions/v1http/events/db_operate.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	"github.com/Tencent/bk-bcs/bcs-common/common/types"
-	msgqueue "github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueuev4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueue"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/drivers"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/operator"
 	"github.com/pkg/errors"

--- a/bcs-services/bcs-storage/storage/actions/v1http/events/utils.go
+++ b/bcs-services/bcs-storage/storage/actions/v1http/events/utils.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	"github.com/Tencent/bk-bcs/bcs-common/common/codec"
 	"github.com/Tencent/bk-bcs/bcs-common/common/types"
-	msgqueue "github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueuev4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueue"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/operator"
 	"github.com/emicklei/go-restful"
 	"go-micro.dev/v4/broker"

--- a/bcs-services/bcs-storage/storage/apiserver/queueOptions.go
+++ b/bcs-services/bcs-storage/storage/apiserver/queueOptions.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/Tencent/bk-bcs/bcs-common/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-common/common/encrypt"
-	msgqueue "github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueuev4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueue"
 )
 
 func getPublishOptions(key string, queueConf *conf.Config) (msgqueue.QueueOption, error) {

--- a/bcs-services/bcs-storage/storage/apiserver/resource.go
+++ b/bcs-services/bcs-storage/storage/apiserver/resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-common/common/encrypt"
 	"github.com/Tencent/bk-bcs/bcs-common/common/http/httpserver"
-	msgqueue "github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueuev4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/msgqueue"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/drivers"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/drivers/mongo"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/odm/operator"
@@ -266,6 +266,7 @@ func (a *APIResource) GetStoreClient(key string) store.Store {
 
 func (a *APIResource) parseMongodb(key string, dbConf *conf.Config) error {
 	address := dbConf.Read(key, "Addr")
+	replicaset := dbConf.Read(key, "Replicaset")
 	timeoutRaw := dbConf.Read(key, "ConnectTimeout")
 	timeout, err := strconv.Atoi(timeoutRaw)
 	if err != nil {
@@ -298,6 +299,7 @@ func (a *APIResource) parseMongodb(key string, dbConf *conf.Config) error {
 
 	mongoOptions := &mongo.Options{
 		Hosts:                 strings.Split(address, ","),
+		Replicaset:            replicaset,
 		ConnectTimeoutSeconds: timeout,
 		Database:              database,
 		Username:              username,

--- a/bcs-services/bcs-storage/storage/storage.go
+++ b/bcs-services/bcs-storage/storage/storage.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/ssl"
 	"github.com/Tencent/bk-bcs/bcs-common/common/types"
 	"github.com/Tencent/bk-bcs/bcs-common/common/version"
-	"github.com/Tencent/bk-bcs/bcs-common/pkg/registryv4"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/registry"
 	trestful "github.com/Tencent/bk-bcs/bcs-common/pkg/tracing/restful"
 	"github.com/emicklei/go-restful"
 	"github.com/opentracing/opentracing-go"
@@ -50,7 +50,7 @@ type StorageServer struct {
 	// micro server
 	microServer *mserver.MicroServer
 	// etcd
-	etcdRegistry registryv4.Registry
+	etcdRegistry registry.Registry
 
 	// 证书
 	etcdTLSConfig *tls.Config
@@ -118,7 +118,7 @@ func (s *StorageServer) registerV1HttpServerToRegistry() {
 		}
 
 		// use go-micro v4 registry
-		eoption := &registryv4.Options{
+		eoption := &registry.Options{
 			Name:         constants.ServerName,
 			Version:      version.BcsVersion,
 			RegistryAddr: strings.Split(s.conf.Etcd.Address, ","),
@@ -127,7 +127,7 @@ func (s *StorageServer) registerV1HttpServerToRegistry() {
 			Meta:         meta,
 		}
 		blog.Infof("#############storage turn on etcd registry feature, options %+v ###############", eoption)
-		s.etcdRegistry = registryv4.NewEtcdRegistry(eoption)
+		s.etcdRegistry = registry.NewEtcdRegistry(eoption)
 	}
 
 }

--- a/install/conf/bcs-services/bcs-storage/storage-database.conf.template
+++ b/install/conf/bcs-services/bcs-storage/storage-database.conf.template
@@ -1,5 +1,6 @@
 [mongodb/dynamic]
 Addr = ${mongodbHost}
+ReplicaSet = ${mongodbReplicaset}
 ConnectTimeout = 0
 Database = dynamic
 Username = ${mongodbUsername}
@@ -11,6 +12,7 @@ ListenerName = commonWatcher
 
 [mongodb/event]
 Addr = ${mongodbEventHost}
+ReplicaSet = ${mongodbReplicaset}
 ConnectTimeout = 0
 Database = event
 Username = ${mongodbEventUsername}
@@ -20,6 +22,7 @@ ListenerName = commonWatcher
 
 [mongodb/alarm]
 Addr = ${mongodbHost}
+ReplicaSet = ${mongodbReplicaset}
 ConnectTimeout = 0
 Database = alarm
 Username = ${mongodbUsername}
@@ -29,6 +32,7 @@ ListenerName = commonWatcher
 
 [mongodb/metric]
 Addr = ${mongodbHost}
+ReplicaSet = ${mongodbReplicaset}
 ConnectTimeout = 0
 Database = metric
 Username = ${mongodbUsername}
@@ -38,6 +42,7 @@ ListenerName = commonWatcher
 
 [mongodb/host]
 Addr = ${mongodbHost}
+ReplicaSet = ${mongodbReplicaset}
 ConnectTimeout = 0
 Database = host
 Username = ${mongodbUsername}
@@ -46,6 +51,7 @@ MaxPoolSize = ${mongodbMaxPoolSize}
 
 [mongodb/clusterConfig]
 Addr = ${mongodbHost}
+ReplicaSet = ${mongodbReplicaset}
 ConnectTimeout = 0
 Database = clusterConfig
 Username = ${mongodbUsername}


### PR DESCRIPTION
go.mod 修改如下：
1. 修改bcs-common依赖的版本
2. 新的common中没有registryv4和msgqueuev4，指定原版本时会出现依赖版本冲突，所以改为registry和msgqueue
3. go mod tidy 出错 `but go 1.16 would select v0.14.0` ，指定 go 版本为 1.18及以上可解决，这里改成使用 1.20

其他修改：
1. Options配置增加字段Replicaset
2. 初始化Mongodb增加使用Replicaset
3. 配置文件增加字段Replicaset

已测试过可正常连接，且不影响原配置