### PR TITLE
feat: project-manager 支持自定义配置projectcode注解(v1.29.x)

### DIFF
--- a/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
+++ b/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
@@ -87,3 +87,5 @@ bcscc:
 bcsGateway:
   host: ""
   token: ""
+sharedClusterConfig:
+  annoKeyProjCode: ""

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create-callback.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create-callback.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/bcscc"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/clientset"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/iam"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/config"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/logging"
 	nsm "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/store/namespace"
 	vdm "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/store/variabledefinition"
@@ -66,8 +67,8 @@ func (a *SharedNamespaceAction) CreateNamespaceCallback(ctx context.Context,
 		namespace := &corev1.Namespace{}
 		namespace.SetName(ns.Name)
 		namespace.SetAnnotations(map[string]string{
-			constant.AnnotationKeyProjectCode: req.GetProjectCode(),
-			constant.AnnotationKeyCreator:     ns.Creator,
+			config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode: req.GetProjectCode(),
+			constant.AnnotationKeyCreator:                         ns.Creator,
 		})
 		_, err = client.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
 		if err != nil {

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/actions/namespace/independent"
-	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/envs"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/clientset"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/itsm"
@@ -50,7 +49,7 @@ func (a *SharedNamespaceAction) CreateNamespace(ctx context.Context,
 	if !config.GlobalConf.ITSM.Enable {
 		ia := independent.NewIndependentNamespaceAction(a.model)
 		req.Annotations = append(req.Annotations, &proto.Annotation{
-			Key:   constant.AnnotationKeyProjectCode,
+			Key:   config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode,
 			Value: req.GetProjectCode(),
 		})
 		return ia.CreateNamespace(ctx, req, resp)

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/native-list.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/native-list.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/component/clientset"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/config"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/logging"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/util/errorx"
 	nsutils "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/util/namespace"
@@ -48,7 +49,7 @@ func (a *SharedNamespaceAction) ListNativeNamespaces(ctx context.Context,
 	}
 	retDatas := []*proto.NativeNamespaceData{}
 	for _, namespace := range namespaces {
-		projectCode, ok := namespace.Annotations[constant.AnnotationKeyProjectCode]
+		projectCode, ok := namespace.Annotations[config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode]
 		if !ok {
 			continue
 		}

--- a/bcs-services/bcs-project-manager/internal/common/envs/envs.go
+++ b/bcs-services/bcs-project-manager/internal/common/envs/envs.go
@@ -14,6 +14,7 @@
 package envs
 
 import (
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/util/stringx"
 )
 
@@ -28,4 +29,7 @@ var (
 	// BCSGatewayToken bcs gateway token
 	BCSGatewayToken    = stringx.GetEnv("gatewayToken", "")
 	BCSNamespacePrefix = stringx.GetEnv("BCS_NAMESPACE_PREFIX", "bcs")
+
+	// AnnotationKeyProjectCode shared cluster project code annotation key
+	AnnotationKeyProjectCode = stringx.GetEnv("annotationKeyProjectCode", constant.AnnotationKeyProjectCode)
 )

--- a/bcs-services/bcs-project-manager/internal/config/config.go
+++ b/bcs-services/bcs-project-manager/internal/config/config.go
@@ -171,6 +171,18 @@ type ListForIAMConfig struct {
 	All  bool     `yaml:"all" usage:"list all projects"`
 }
 
+// TaskConfig option for dispatch task broker & worker
+type TaskConfig struct {
+	QueueAddress string `yaml:"address"`
+	Exchange     string `yaml:"exchange"`
+	WorkerCnt    int    `yaml:"workerCnt"`
+}
+
+// SharedClusterConfig 共享集群相关配置
+type SharedClusterConfig struct {
+	AnnoKeyProjCode string `yaml:"annoKeyProjCode"`
+}
+
 // ProjectConfig 项目的配置信息
 type ProjectConfig struct {
 	Etcd                   EtcdConfig                   `yaml:"etcd"`
@@ -189,6 +201,7 @@ type ProjectConfig struct {
 	App                    AppConfig                    `yaml:"app"`
 	BcsGateway             BCSGatewayConfig             `yaml:"bcsGateway"`
 	ListForIAM             ListForIAMConfig             `yaml:"listForIAM"`
+	SharedClusterConfig    SharedClusterConfig          `yaml:"sharedClusterConfig"`
 }
 
 func (conf *ProjectConfig) initServerAddress() {
@@ -207,6 +220,9 @@ func (conf *ProjectConfig) initFromEnv() {
 	}
 	if conf.BcsGateway.Token == "" {
 		conf.BcsGateway.Token = envs.BCSGatewayToken
+	}
+	if conf.SharedClusterConfig.AnnoKeyProjCode == "" {
+		conf.SharedClusterConfig.AnnoKeyProjCode = envs.AnnotationKeyProjectCode
 	}
 }
 

--- a/bcs-services/bcs-project-manager/internal/util/namespace/namespace.go
+++ b/bcs-services/bcs-project-manager/internal/util/namespace/namespace.go
@@ -17,13 +17,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/common/constant"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/internal/config"
 )
 
 // FilterNamespaces filter shared namespace
 func FilterNamespaces(namespaceList *corev1.NamespaceList, shared bool, projectCode string) []corev1.Namespace {
 	nsList := []corev1.Namespace{}
 	for _, ns := range namespaceList.Items {
-		if shared && ns.Annotations[constant.AnnotationKeyProjectCode] != projectCode {
+		if shared && ns.Annotations[config.GlobalConf.SharedClusterConfig.AnnoKeyProjCode] != projectCode {
 			continue
 		}
 		nsList = append(nsList, ns)


### PR DESCRIPTION
目前共享集群中命名空间所属的项目都是通过 io.tencent.bcs.projectcode 这个注解来区分的，有场景的使用需求是这个注解的key是可配置的。

修改配置中增加了对该值的配置字段，在调用处替换为使用配置值。在初始化时为配置该字段则默认使用 io.tencent.bcs.projectcode，兼容原有配置。