### PR TITLE
feat: cmdb-synchronizer支持自定义配置projectcode注解(v1.29.x)

### DIFF
--- a/bcs-services/bcs-bkcmdb-synchronizer/config/bcs-bkcmdb-synchronizer.json.template
+++ b/bcs-services/bcs-bkcmdb-synchronizer/config/bcs-bkcmdb-synchronizer.json.template
@@ -45,5 +45,8 @@
     "bk_username": "${cmdb_bkUsername}",
     "server": "${cmdb_server}",
     "debug": ${cmdb_debug}
+  },
+  "shared_cluster": {
+    "annotation_key_proj_code": "${sharedCluster_annoKeyProjCode}"
   }
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -1694,7 +1694,8 @@ func (b *BcsBkcmdbSynchronizerHandler) handleNamespaceCreate(namespace *corev1.N
 	}
 
 	bizid := b.BkCluster.BizID
-	if projectCode, ok := namespace.Annotations["io.tencent.bcs.projectcode"]; ok {
+	annotationKey := b.Syncer.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode
+	if projectCode, ok := namespace.Annotations[annotationKey]; ok {
 		gpr := pmp.GetProjectRequest{
 			ProjectIDOrCode: projectCode,
 		}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
@@ -17,12 +17,13 @@ import "github.com/Tencent/bk-bcs/bcs-common/common/conf"
 
 // BkcmdbSynchronizerOption options for CostManager
 type BkcmdbSynchronizerOption struct {
-	Synchronizer SynchronizerConfig `json:"synchronizer" value:"synchronizer"`
-	Client       ClientConfig       `json:"client"`
-	Bcslog       conf.LogConfig     `json:"bcslog"`
-	Bcsapi       BcsapiConfig       `json:"bcsapi"`
-	RabbitMQ     RabbitMQConfig     `json:"rabbitmq"`
-	CMDB         CMDBConfig         `json:"cmdb"`
+	Synchronizer  SynchronizerConfig  `json:"synchronizer" value:"synchronizer"`
+	Client        ClientConfig        `json:"client"`
+	Bcslog        conf.LogConfig      `json:"bcslog"`
+	Bcsapi        BcsapiConfig        `json:"bcsapi"`
+	RabbitMQ      RabbitMQConfig      `json:"rabbitmq"`
+	CMDB          CMDBConfig          `json:"cmdb"`
+	SharedCluster SharedClusterConfig `json:"shared_cluster"`
 }
 
 // SynchronizerConfig synchronizer config
@@ -69,4 +70,9 @@ type CMDBConfig struct {
 	BKUserName string `json:"bk_username"`
 	Server     string `json:"server"`
 	Debug      bool   `json:"debug"`
+}
+
+// SharedClusterConfig shared cluster config
+type SharedClusterConfig struct {
+	AnnotationKeyProjCode string `json:"annotation_key_proj_code"`
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -328,7 +328,7 @@ func (s *Syncer) SyncNamespaces(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Clus
 			}
 		} else {
 			bizid := bkCluster.BizID
-			if projectCode, ok := v.Data.Annotations["io.tencent.bcs.projectcode"]; ok {
+			if projectCode, ok := v.Data.Annotations[s.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode]; ok {
 				gpr := pmp.GetProjectRequest{
 					ProjectIDOrCode: projectCode,
 				}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/synchronizer/synchronizer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/synchronizer/synchronizer.go
@@ -114,6 +114,7 @@ func (s *Synchronizer) Init() {
 		blog.Errorf("init mq failed, err: %s", err.Error())
 	}
 
+	s.initSharedClusterConf()
 }
 
 func (s *Synchronizer) initTlsConfig() error {
@@ -156,6 +157,12 @@ func (s *Synchronizer) initMQ() error {
 	s.MQ = rabbitmq.NewRabbitMQ(&s.BkcmdbSynchronizerOption.RabbitMQ)
 
 	return nil
+}
+
+func (s *Synchronizer) initSharedClusterConf() {
+	if s.Syncer.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode == "" {
+		s.Syncer.BkcmdbSynchronizerOption.SharedCluster.AnnotationKeyProjCode = "io.tencent.bcs.projectcode"
+	}
 }
 
 // Run run the synchronizer

--- a/install/conf/bcs-services/bcs-bkcmdb-synchronizer/bcs-bkcmdb-synchronizer.json.template
+++ b/install/conf/bcs-services/bcs-bkcmdb-synchronizer/bcs-bkcmdb-synchronizer.json.template
@@ -45,5 +45,8 @@
     "bk_username": "${cmdb_bkUsername}",
     "server": "${cmdb_server}",
     "debug": ${cmdb_debug}
+  },
+  "shared_cluster": {
+    "annotation_key_proj_code": "${sharedCluster_annoKeyProjCode}"
   }
 }


### PR DESCRIPTION
目前共享集群中命名空间所属的项目都是通过 io.tencent.bcs.projectcode 这个注解来区分的，有场景的使用需求是这个注解的key是可配置的。

修改配置中增加了对该值的配置字段，在调用处替换为使用配置值。在初始化时为配置该字段则默认使用 io.tencent.bcs.projectcode，兼容原有配置。