### PR TITLE
fix: 取消nodetemplate相关接口的越权访问(v1.29.x)

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/auth/preset.go
+++ b/bcs-services/bcs-cluster-manager/internal/auth/preset.go
@@ -57,13 +57,6 @@ var NoAuthMethod = []string{
 	"ClusterManager.SyncAutoScalingOption",
 	"ClusterManager.UpdateAsOptionDeviceProvider",
 
-	// nodeTemplate
-	"ClusterManager.CreateNodeTemplate",
-	"ClusterManager.UpdateNodeTemplate",
-	"ClusterManager.DeleteNodeTemplate",
-	"ClusterManager.ListNodeTemplate",
-	"ClusterManager.GetNodeTemplate",
-
 	// cloud account
 	"ClusterManager.CreateCloudAccount",
 	"ClusterManager.ListCloudAccount",


### PR DESCRIPTION
在NoAuthMethod中去掉Node template相关接口