### PR TITLE
fix: 修复腾讯云、谷歌云、亚马逊云、微软云的bug

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/actions/account/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/account/list.go
@@ -94,7 +94,7 @@ func (la *ListAction) listCloudAccount() error {
 		cloudAccounts[i].UpdateTime = utils.TransTimeFormat(cloudAccounts[i].UpdateTime)
 
 		cloudAccountInfo := &cmproto.CloudAccountInfo{
-			Account:  &cloudAccounts[i],
+			Account:  cloudAccounts[i],
 			Clusters: clusterIDs,
 		}
 		accountList = append(accountList, cloudAccounts[i].AccountID)
@@ -245,7 +245,7 @@ func (la *ListPermDataAction) listCloudAccount() error {
 		}
 		cloudAccounts[i].Account.SecretKey = ""
 		cloudAccounts[i].Account.SecretID = ""
-		la.cloudAccountList = append(la.cloudAccountList, &cloudAccounts[i])
+		la.cloudAccountList = append(la.cloudAccountList, cloudAccounts[i])
 	}
 	return nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/actions/account/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/account/utils.go
@@ -37,7 +37,7 @@ type CloudAccount struct {
 
 // getAllAccountsByCloudID list all accounts by cloud
 func getAllAccountsByCloudID(
-	ctx context.Context, model store.ClusterManagerModel, cloudID string) ([]proto.CloudAccount, error) {
+	ctx context.Context, model store.ClusterManagerModel, cloudID string) ([]*proto.CloudAccount, error) {
 	condM := make(operator.M)
 	condM[account.CloudKey] = cloudID
 	cond := operator.NewLeafCondition(operator.Eq, condM)

--- a/bcs-services/bcs-cluster-manager/internal/actions/autoscalingoption/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/autoscalingoption/list.go
@@ -61,9 +61,7 @@ func (la *ListAction) listAutoScalingOption() error {
 	if err != nil {
 		return err
 	}
-	for i := range options {
-		la.optionList = append(la.optionList, &options[i])
-	}
+	la.optionList = append(la.optionList, options...)
 	return nil
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/actions/cloud/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cloud/list.go
@@ -70,7 +70,7 @@ func (la *ListAction) listCloud() error {
 			continue
 		}
 
-		la.cloudList = append(la.cloudList, &clouds[i])
+		la.cloudList = append(la.cloudList, clouds[i])
 	}
 	return nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/actions/cloudvpc/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cloudvpc/list.go
@@ -87,7 +87,7 @@ func (la *ListAction) listCloudVPC() error {
 
 		barrier.Add(1)
 		// query available vpc
-		go func(vpc cmproto.CloudVPC) {
+		go func(vpc *cmproto.CloudVPC) {
 			defer func() {
 				barrier.Done()
 			}()
@@ -132,7 +132,7 @@ func (la *ListAction) listCloudVPC() error {
 	return nil
 }
 
-func getAvailableIPNumByVpc(model store.ClusterManagerModel, ipType string, vpc cmproto.CloudVPC) (uint32, error) {
+func getAvailableIPNumByVpc(model store.ClusterManagerModel, ipType string, vpc *cmproto.CloudVPC) (uint32, error) {
 	cloud, err := actions.GetCloudByCloudID(model, vpc.CloudID)
 	if err != nil {
 		blog.Errorf("getAvailableIPNumByVpc[%s:%s] failed: %v", vpc.Region, vpc.VpcID, err)

--- a/bcs-services/bcs-cluster-manager/internal/actions/cluster/delete.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cluster/delete.go
@@ -41,8 +41,8 @@ type DeleteAction struct {
 	model             store.ClusterManagerModel
 	cluster           *cmproto.Cluster
 	nodes             []*cmproto.Node
-	quotaList         []cmproto.ResourceQuota
-	nodeGroups        []cmproto.NodeGroup
+	quotaList         []*cmproto.ResourceQuota
+	nodeGroups        []*cmproto.NodeGroup
 	lastClusterStatus string
 
 	kube *clusterops.K8SOperator
@@ -234,7 +234,7 @@ func (da *DeleteAction) deleteRelativeResource() error {
 	//! we don't delete it here, we delete it after all Nodes are releasing
 	for _, group := range da.nodeGroups {
 		group.Status = common.StatusDeleting
-		if err := da.model.UpdateNodeGroup(da.ctx, &group); err != nil {
+		if err := da.model.UpdateNodeGroup(da.ctx, group); err != nil {
 			blog.Errorf("setting Cluster %s relative NodeGroup %s to status DELETING failed, %s",
 				da.req.ClusterID, group.NodeGroupID, err.Error())
 			return err

--- a/bcs-services/bcs-cluster-manager/internal/actions/cluster/get.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cluster/get.go
@@ -96,10 +96,39 @@ func (ga *GetAction) getCluster() error {
 		}
 	}
 
+	// sort cluster shared range, current project first
+	ga.sortSharedRangeProjectIDorCodes()
+
 	// append module info
 	ga.appendModuleInfo()
 
 	return nil
+}
+
+func (ga *GetAction) sortSharedRangeProjectIDorCodes() {
+	sharedRanges := ga.cluster.GetSharedRanges()
+	if sharedRanges == nil {
+		return
+	}
+
+	if len(sharedRanges.GetProjectIdOrCodes()) == 0 {
+		return
+	}
+
+	projectIDorCodes := sharedRanges.GetProjectIdOrCodes()
+	currentProjectID := ga.cluster.GetProjectID()
+
+	remainProjectIDorCodes := make([]string, 0, len(projectIDorCodes))
+	for _, id := range projectIDorCodes {
+		if id != currentProjectID {
+			remainProjectIDorCodes = append(remainProjectIDorCodes, id)
+		}
+	}
+
+	sorted := make([]string, 0, 1+len(remainProjectIDorCodes))
+	sorted = append(sorted, append([]string{currentProjectID}, remainProjectIDorCodes...)...)
+
+	ga.cluster.SharedRanges.ProjectIdOrCodes = sorted
 }
 
 func (ga *GetAction) appendModuleInfo() {
@@ -697,7 +726,7 @@ func (ga *GetClusterSharedProjectAction) getSharedProject() error {
 
 	// if projectIDorCodes is empty, use cluster's projectID for sharedproject
 	// only one value not use goroutine
-	if projectIDorCodes == nil || len(projectIDorCodes) == 0 {
+	if len(projectIDorCodes) == 0 {
 		projectID := cluster.GetProjectID()
 		if projectID != "" {
 			pInfo, err := project.GetProjectManagerClient().GetProjectInfo(projectID, true)

--- a/bcs-services/bcs-cluster-manager/internal/actions/cluster/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cluster/list.go
@@ -118,7 +118,7 @@ func (la *ListAction) getSharedCluster() error {
 		if clusterList[i].GetProjectID() == la.req.ProjectID {
 			continue
 		}
-		la.clusterList = append(la.clusterList, shieldClusterInfo(&clusterList[i]))
+		la.clusterList = append(la.clusterList, shieldClusterInfo(clusterList[i]))
 		clusterIDs = append(clusterIDs, clusterList[i].ClusterID)
 	}
 
@@ -144,10 +144,10 @@ func (la *ListAction) getSharedCluster() error {
 	return nil
 }
 
-func (la *ListAction) filterClusterList() ([]cmproto.Cluster, bool, error) {
+func (la *ListAction) filterClusterList() ([]*cmproto.Cluster, bool, error) {
 	var (
 		sharedCluster = true
-		clusterList   []cmproto.Cluster
+		clusterList   []*cmproto.Cluster
 		err           error
 	)
 
@@ -217,7 +217,7 @@ func (la *ListAction) listCluster() error {
 		if clusterList[i].IsShared {
 			clusterList[i].IsShared = false
 		}
-		la.clusterList = append(la.clusterList, shieldClusterInfo(&clusterList[i]))
+		la.clusterList = append(la.clusterList, shieldClusterInfo(clusterList[i]))
 		clusterIDList = append(clusterIDList, clusterList[i].ClusterID)
 	}
 
@@ -372,9 +372,9 @@ func (la *ListProjectClusterAction) listProjectCluster() error {
 		}
 
 		if clusterList[i].Status == common.StatusRunning {
-			runningCluster = append(runningCluster, shieldClusterInfo(&clusterList[i]))
+			runningCluster = append(runningCluster, shieldClusterInfo(clusterList[i]))
 		} else {
-			otherCluster = append(otherCluster, shieldClusterInfo(&clusterList[i]))
+			otherCluster = append(otherCluster, shieldClusterInfo(clusterList[i]))
 		}
 		clusterIDList = append(clusterIDList, clusterList[i].ClusterID)
 	}
@@ -568,7 +568,7 @@ func (la *ListCommonClusterAction) listCluster() error {
 		}
 
 		// 平台共享集群
-		la.clusterList = append(la.clusterList, shieldClusterInfo(&clusterList[i]))
+		la.clusterList = append(la.clusterList, shieldClusterInfo(clusterList[i]))
 		clusterIDList = append(clusterIDList, clusterList[i].ClusterID)
 	}
 
@@ -985,7 +985,7 @@ func getUserClusterPermList(iam iam.PermClient, user actions.PermInfo,
 }
 
 // getCloudProviderEngine get cluster cloud engineType
-func getCloudProviderEngine(model store.ClusterManagerModel, cls cmproto.Cluster) string {
+func getCloudProviderEngine(model store.ClusterManagerModel, cls *cmproto.Cluster) string {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1000,7 +1000,7 @@ func getCloudProviderEngine(model store.ClusterManagerModel, cls cmproto.Cluster
 
 // returnClusterExtraInfo return cluster extra info
 func returnClusterExtraInfo(model store.ClusterManagerModel,
-	clusterList []cmproto.Cluster) map[string]*cmproto.ExtraInfo {
+	clusterList []*cmproto.Cluster) map[string]*cmproto.ExtraInfo {
 	extraInfo := make(map[string]*cmproto.ExtraInfo, 0)
 
 	// cluster extra info
@@ -1039,7 +1039,7 @@ func getSharedCluster(projectId string, bizId string, model store.ClusterManager
 			utils.StringContainInSlice(projectId, clusterList[i].SharedRanges.ProjectIdOrCodes)) ||
 			(len(clusterList[i].SharedRanges.GetBizs()) > 0 && len(bizId) > 0 &&
 				utils.StringContainInSlice(bizId, clusterList[i].SharedRanges.GetBizs()))) {
-			clusters = append(clusters, shieldClusterInfo(&clusterList[i]))
+			clusters = append(clusters, shieldClusterInfo(clusterList[i]))
 
 			continue
 		}
@@ -1048,7 +1048,7 @@ func getSharedCluster(projectId string, bizId string, model store.ClusterManager
 		if clusterList[i].SharedRanges == nil || (clusterList[i].SharedRanges != nil &&
 			(len(clusterList[i].SharedRanges.GetProjectIdOrCodes()) == 0 &&
 				len(clusterList[i].SharedRanges.GetBizs()) == 0)) {
-			clusters = append(clusters, shieldClusterInfo(&clusterList[i]))
+			clusters = append(clusters, shieldClusterInfo(clusterList[i]))
 			continue
 		}
 	}

--- a/bcs-services/bcs-cluster-manager/internal/actions/cluster/update_vcluster_quota.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cluster/update_vcluster_quota.go
@@ -89,7 +89,7 @@ func (ua *UpdateVirtualClusterQuotaAction) Handle(ctx context.Context, req *cmpr
 		return
 	}
 
-	var nsInfo cmproto.NamespaceInfo
+	var nsInfo *cmproto.NamespaceInfo
 	err = utils.ToStringObject([]byte(ua.cluster.ExtraInfo[common.VClusterNamespaceInfo]), &nsInfo)
 	if err != nil {
 		ua.setResp(common.BcsErrClusterManagerCloudProviderErr, err.Error())

--- a/bcs-services/bcs-cluster-manager/internal/actions/cluster/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/cluster/utils.go
@@ -107,7 +107,7 @@ func getClusterMaxNum(clusterType string, env string, model store.ClusterManager
 }
 
 // getClusterList get all cm clusters
-func getClusterList(model store.ClusterManagerModel) ([]proto.Cluster, error) {
+func getClusterList(model store.ClusterManagerModel) ([]*proto.Cluster, error) {
 	clusterStatus := []string{common.StatusInitialization, common.StatusRunning, common.StatusDeleting}
 	condStatus := operator.NewLeafCondition(operator.In, operator.M{"status": clusterStatus})
 
@@ -135,7 +135,7 @@ func selectVclusterHostCluster(model store.ClusterManagerModel, filter VClusterH
 		"provider": filter.Provider,
 	})
 
-	filterHostClusters := make([]proto.Cluster, 0)
+	filterHostClusters := make([]*proto.Cluster, 0)
 
 	condStatus := operator.NewLeafCondition(operator.Ne, operator.M{"status": common.StatusDeleted})
 	branchCond := operator.NewBranchCondition(operator.And, condCluster, condStatus)
@@ -714,7 +714,7 @@ func asyncDeleteImportedClusterInfo(ctx context.Context, store store.ClusterMana
 }
 
 // IsSupportAutoScale support autoscale feat
-func IsSupportAutoScale(store store.ClusterManagerModel, cls proto.Cluster) bool {
+func IsSupportAutoScale(store store.ClusterManagerModel, cls *proto.Cluster) bool {
 	cloudId := cls.GetProvider()
 	if cloudId == "" {
 		return false

--- a/bcs-services/bcs-cluster-manager/internal/actions/clustercredential/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/clustercredential/list.go
@@ -67,9 +67,7 @@ func (la *ListAction) listClusterCredential() error {
 	if err != nil {
 		return err
 	}
-	for i := range clusterCredentialList {
-		la.clusterCredentialList = append(la.clusterCredentialList, &clusterCredentialList[i])
-	}
+	la.clusterCredentialList = append(la.clusterCredentialList, clusterCredentialList...)
 	return nil
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/actions/moduleflag/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/moduleflag/list.go
@@ -80,14 +80,14 @@ func (la *ListAction) listCloudModuleFlag() error {
 
 	for i := range cloudModuleFlags {
 		cloudModuleFlags[i].FlagDesc = i18n.T(la.ctx, cloudModuleFlags[i].FlagDesc)
-		la.moduleFlagListList = append(la.moduleFlagListList, &cloudModuleFlags[i])
+		la.moduleFlagListList = append(la.moduleFlagListList, cloudModuleFlags[i])
 	}
 
 	return nil
 }
 
 func getCommonModuleFlags(model store.ClusterManagerModel, cloudID, moduleID string) (
-	[]cmproto.CloudModuleFlag, error) {
+	[]*cmproto.CloudModuleFlag, error) {
 	condM := make(operator.M)
 	condM["cloudid"] = cloudID
 	condM["moduleid"] = moduleID

--- a/bcs-services/bcs-cluster-manager/internal/actions/nodegroup/update.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/nodegroup/update.go
@@ -403,14 +403,15 @@ func (ua *UpdateAction) updateCloudNodeGroup() error {
 			)
 			return err
 		}
+		// update group info
+		if err = ua.saveNodeGroupStatus(common.StatusNodeGroupUpdating); err != nil {
+			return err
+		}
+
 		if err = taskserver.GetTaskServer().Dispatch(task); err != nil {
 			blog.Errorf("dispatch update nodegroup task for nodegroup %s failed, %s",
 				ua.group.NodeGroupID, err.Error(),
 			)
-			return err
-		}
-		// update group info
-		if err = ua.saveNodeGroupStatus(common.StatusNodeGroupUpdating); err != nil {
 			return err
 		}
 

--- a/bcs-services/bcs-cluster-manager/internal/actions/nodegroup/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/nodegroup/utils.go
@@ -64,7 +64,7 @@ func listNodeGroupByConds(model store.ClusterManagerModel, options filterNodeGro
 		return nil, err
 	}
 	for i := range groups {
-		groupList = append(groupList, removeSensitiveInfo(&groups[i]))
+		groupList = append(groupList, removeSensitiveInfo(groups[i]))
 	}
 	return groupList, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/actions/nodetemplate/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/nodetemplate/list.go
@@ -69,16 +69,16 @@ func (la *ListAction) listNodeTemplates() error {
 	for i := range templates {
 		templates[i].UpdateTime = utils.TransTimeFormat(templates[i].UpdateTime)
 		templates[i].CreateTime = utils.TransTimeFormat(templates[i].CreateTime)
-		err = decodeTemplateScript(&templates[i])
+		err = decodeTemplateScript(templates[i])
 		if err != nil {
 			return err
 		}
-		err = decodeAction(&templates[i])
+		err = decodeAction(templates[i])
 		if err != nil {
 			return err
 		}
 
-		la.nodeTemplateList = append(la.nodeTemplateList, &templates[i])
+		la.nodeTemplateList = append(la.nodeTemplateList, templates[i])
 	}
 	return nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/actions/nodetemplate/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/nodetemplate/utils.go
@@ -30,7 +30,7 @@ const (
 
 // getAllNodeTemplates list all nodeTemplates
 func getAllNodeTemplates(
-	ctx context.Context, model store.ClusterManagerModel, projectID string) ([]proto.NodeTemplate, error) {
+	ctx context.Context, model store.ClusterManagerModel, projectID string) ([]*proto.NodeTemplate, error) {
 	condM := make(operator.M)
 	condM[nodetemplate.ProjectIDKey] = projectID
 	cond := operator.NewLeafCondition(operator.Eq, condM)

--- a/bcs-services/bcs-cluster-manager/internal/actions/notifytemplate/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/notifytemplate/list.go
@@ -68,7 +68,7 @@ func (la *ListAction) listNotifyTemplates() error {
 		templates[i].UpdateTime = utils.TransTimeFormat(templates[i].UpdateTime)
 		templates[i].CreateTime = utils.TransTimeFormat(templates[i].CreateTime)
 
-		la.notifyTemplateList = append(la.notifyTemplateList, &templates[i])
+		la.notifyTemplateList = append(la.notifyTemplateList, templates[i])
 	}
 	return nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/actions/notifytemplate/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/notifytemplate/utils.go
@@ -26,7 +26,7 @@ import (
 
 // getAllNotifyTemplates list all notifyTemplates
 func getAllNotifyTemplates(
-	ctx context.Context, model store.ClusterManagerModel, projectID string) ([]proto.NotifyTemplate, error) {
+	ctx context.Context, model store.ClusterManagerModel, projectID string) ([]*proto.NotifyTemplate, error) {
 	condM := make(operator.M)
 	condM[nodetemplate.ProjectIDKey] = projectID
 	cond := operator.NewLeafCondition(operator.Eq, condM)

--- a/bcs-services/bcs-cluster-manager/internal/actions/operationlog/operationlog.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/operationlog/operationlog.go
@@ -61,7 +61,7 @@ func (ua *ListOperationLogsAction) setResp(code uint32, msg string) {
 	ua.resp.Result = (code == common.BcsErrClusterManagerSuccess)
 }
 
-func (ua *ListOperationLogsAction) filterOperationLogs() ([]cmproto.TaskOperationLog, int, error) {
+func (ua *ListOperationLogsAction) filterOperationLogs() ([]*cmproto.TaskOperationLog, int, error) {
 	var (
 		conds   = make([]bson.E, 0)
 		condDst = make([]bson.E, 0)
@@ -250,7 +250,7 @@ func (ua *ListOperationLogsAction) appendTasks(taskIDs []string) error {
 	}
 	taskMap := make(map[string]*cmproto.Task, 0)
 	for i := range tasks {
-		taskMap[tasks[i].TaskID] = &tasks[i]
+		taskMap[tasks[i].TaskID] = tasks[i]
 	}
 	for i, v := range ua.resp.Data.Results {
 		if t, ok := taskMap[v.TaskID]; ok {

--- a/bcs-services/bcs-cluster-manager/internal/actions/task/list.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/task/list.go
@@ -79,16 +79,16 @@ func (la *ListAction) listTask() error {
 		return err
 	}
 	for i := range tasks {
-		utils.HandleTaskStepData(la.ctx, &tasks[i])
+		utils.HandleTaskStepData(la.ctx, tasks[i])
 		// actions.FormatTaskTime(&tasks[i])
 
 		if len(la.req.NodeIP) > 0 {
 			exist := iutils.StringContainInSlice(la.req.NodeIP, tasks[i].NodeIPList)
 			if exist {
-				la.TaskList = append(la.TaskList, &tasks[i])
+				la.TaskList = append(la.TaskList, tasks[i])
 			}
 		} else {
-			la.TaskList = append(la.TaskList, &tasks[i])
+			la.TaskList = append(la.TaskList, tasks[i])
 		}
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/actions/thirdparty/project_quota.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/thirdparty/project_quota.go
@@ -40,7 +40,7 @@ type GetProjectResourceQuotaUsageAction struct {
 	projectId string
 	cloud     *cmproto.Cloud
 
-	groups []cmproto.NodeGroup
+	groups []*cmproto.NodeGroup
 
 	regionInsTypes map[string][]string // nolint
 }

--- a/bcs-services/bcs-cluster-manager/internal/actions/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/utils.go
@@ -99,7 +99,7 @@ func GetAsOptionByClusterID(
 
 // GetProjectClusters get project cluster list
 func GetProjectClusters(ctx context.Context, model store.ClusterManagerModel, projectID string) (
-	[]proto.Cluster, error) {
+	[]*proto.Cluster, error) {
 	condCluster := operator.NewLeafCondition(operator.Eq, operator.M{
 		"projectid": projectID,
 	})
@@ -118,7 +118,7 @@ func GetProjectClusters(ctx context.Context, model store.ClusterManagerModel, pr
 
 // GetCloudClusters get project cluster list
 func GetCloudClusters(ctx context.Context, model store.ClusterManagerModel, cloudID, accountID, vpcID string) (
-	[]proto.Cluster, error) {
+	[]*proto.Cluster, error) {
 	condCluster := operator.NewLeafCondition(operator.Eq, operator.M{
 		"provider":       cloudID,
 		"cloudaccountid": accountID,

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/api/as.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/api/as.go
@@ -110,3 +110,37 @@ func (as *AutoScalingClient) DetachInstances(input *autoscaling.DetachInstancesI
 
 	return output.Activities, nil
 }
+
+// DescribeLifecycleHooks list all lifecycle hooks in AutoScalingGroups
+func (as *AutoScalingClient) DescribeLifecycleHooks(asName *string) ([]*autoscaling.LifecycleHook, error) {
+	blog.Infof("DescribeLifecycleHooks asName: %s", asName)
+
+	output, err := as.asClient.DescribeLifecycleHooks(&autoscaling.DescribeLifecycleHooksInput{
+		AutoScalingGroupName: asName,
+	})
+	if err != nil {
+		blog.Errorf("DescribeLifecycleHooks failed: %v", err)
+		return nil, err
+	}
+	blog.Infof("DescribeLifecycleHooks find hooks %s", output.GoString())
+
+	return output.LifecycleHooks, nil
+}
+
+// DeleteLifecycleHooks delete lifecycle hooks in AutoScalingGroups
+func (as *AutoScalingClient) DeleteLifecycleHooks(asName *string, hookName []string) error {
+	for _, hook := range hookName {
+		_, err := as.asClient.DeleteLifecycleHook(&autoscaling.DeleteLifecycleHookInput{
+			AutoScalingGroupName: asName,
+			LifecycleHookName:    &hook,
+		})
+		if err != nil {
+			blog.Errorf("DeleteLifecycleHook failed: %s", err)
+			return err
+		}
+
+		blog.Infof("DeleteLifecycleHooks delete hooks %s successful", hook)
+	}
+
+	return nil
+}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cloud.go
@@ -114,7 +114,7 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *cmproto.Cluster,
 	}
 
 	// cluster cloud basic setting
-	clusterBasicSettingByEks(cls, cluster)
+	clusterBasicSettingByEks(cls, cluster, opt)
 
 	// cluster cloud network setting
 	clusterNetworkSettingByEks(cls, cluster, ipv4Cidr, ipv6Cidr)
@@ -122,10 +122,12 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *cmproto.Cluster,
 	return nil
 }
 
-func clusterBasicSettingByEks(cls *cmproto.Cluster, cluster *eks.Cluster) {
+func clusterBasicSettingByEks(cls *cmproto.Cluster, cluster *eks.Cluster,
+	opt *cloudprovider.SyncClusterCloudInfoOption) {
 	cls.ClusterBasicSettings = &cmproto.ClusterBasicSetting{
 		Version:     *cluster.Version,
 		VersionName: *cluster.Version,
+		Area:        opt.Area,
 	}
 	// if cluster.NodeConfig != nil {
 	// 	cls.ClusterBasicSettings.OS = cluster.NodeConfig.ImageType

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cluster.go
@@ -174,6 +174,14 @@ func (c *Cluster) GetCluster(cloudID string, opt *cloudprovider.GetClusterOption
 		}
 	}
 
+	if opt.Cluster.ClusterAdvanceSettings.NetworkType == "" {
+		opt.Cluster.ClusterAdvanceSettings.NetworkType = common.VpcCni
+	}
+
+	if opt.Cluster.NetworkType == "" {
+		opt.Cluster.NetworkType = common.ClusterUnderlayNetwork
+	}
+
 	return opt.Cluster, nil
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/nodegroup.go
@@ -86,23 +86,33 @@ func (ng *NodeGroup) UpdateNodeGroup(
 		blog.Errorf("get cluster %s failed, %s", group.ClusterID, err.Error())
 		return nil, err
 	}
+
 	eksCli, err := api.NewEksClient(&opt.CommonOption)
 	if err != nil {
 		blog.Errorf("create eks client failed, err: %s", err.Error())
 		return nil, err
 	}
+
 	if group.NodeGroupID == "" || group.ClusterID == "" {
 		blog.Errorf("nodegroup id or cluster id is empty")
 		return nil, fmt.Errorf("nodegroup id or cluster id is empty")
 	}
-	_, err = eksCli.UpdateNodegroupConfig(ng.generateUpdateNodegroupConfigInput(group, cluster.SystemID))
+
+	cloudNg, err := eksCli.DescribeNodegroup(&group.CloudNodeGroupID, &cluster.SystemID)
+	if err != nil {
+		blog.Errorf("get cloud nodegroup failed, err: %s", err.Error())
+		return nil, err
+	}
+
+	_, err = eksCli.UpdateNodegroupConfig(ng.generateUpdateNodegroupConfigInput(group, cloudNg, cluster.SystemID))
 	if err != nil {
 		return nil, err
 	}
+
 	return nil, nil
 }
 
-func (ng *NodeGroup) generateUpdateNodegroupConfigInput(group *proto.NodeGroup,
+func (ng *NodeGroup) generateUpdateNodegroupConfigInput(group *proto.NodeGroup, cloudNg *eks.Nodegroup,
 	cluster string) *eks.UpdateNodegroupConfigInput {
 	input := &eks.UpdateNodegroupConfigInput{
 		ClusterName:   &cluster,
@@ -111,19 +121,52 @@ func (ng *NodeGroup) generateUpdateNodegroupConfigInput(group *proto.NodeGroup,
 
 	if len(group.GetNodeTemplate().GetLabels()) > 0 {
 		input.Labels = &eks.UpdateLabelsPayload{
-			AddOrUpdateLabels: aws.StringMap(group.GetNodeTemplate().GetLabels()),
+			AddOrUpdateLabels: aws.StringMap(group.NodeTemplate.Labels),
 		}
+
+		for k := range cloudNg.Labels {
+			if _, ok := group.NodeTemplate.Labels[k]; !ok {
+				input.Labels.RemoveLabels = append(input.Labels.RemoveLabels, aws.String(k))
+			}
+		}
+	} else if len(cloudNg.Labels) > 0 {
+		input.Labels = &eks.UpdateLabelsPayload{}
+		for k := range cloudNg.Labels {
+			input.Labels.RemoveLabels = append(input.Labels.RemoveLabels, aws.String(k))
+		}
+	}
+
+	if len(group.GetNodeTemplate().GetTaints()) > 0 {
+		input.Taints = &eks.UpdateTaintsPayload{
+			AddOrUpdateTaints: api.MapToAwsTaints(group.NodeTemplate.Taints),
+		}
+
+		for _, v := range cloudNg.Taints {
+			exit := false
+			for _, y := range group.NodeTemplate.Taints {
+				if *v.Key == y.Key {
+					exit = true
+					continue
+				}
+			}
+
+			if !exit {
+				input.Taints.RemoveTaints = append(input.Taints.RemoveTaints, &eks.Taint{
+					Key:    v.Key,
+					Value:  v.Value,
+					Effect: v.Effect,
+				})
+			}
+		}
+	} else if len(cloudNg.Taints) > 0 {
+		input.Taints = &eks.UpdateTaintsPayload{}
+		input.Taints.RemoveTaints = append(input.Taints.RemoveTaints, cloudNg.Taints...)
 	}
 
 	if group.AutoScaling != nil {
 		input.ScalingConfig = &eks.NodegroupScalingConfig{
 			MaxSize: aws.Int64(int64(group.AutoScaling.MaxSize)),
 			MinSize: aws.Int64(int64(group.AutoScaling.MinSize)),
-		}
-	}
-	if group.NodeTemplate != nil && group.NodeTemplate.Taints != nil {
-		input.Taints = &eks.UpdateTaintsPayload{
-			AddOrUpdateTaints: api.MapToAwsTaints(group.NodeTemplate.Taints),
 		}
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/nodegroup.go
@@ -443,7 +443,7 @@ func (ng *NodeGroup) CheckResourcePoolQuota(group *proto.NodeGroup, scaleUpNum u
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup,
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup,
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 	return nil, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createCluster.go
@@ -379,8 +379,8 @@ func createAddon(ctx context.Context, info *cloudprovider.CloudDependBasicInfo) 
 	for _, addon := range defaultAddons {
 		// 调用CreateAddon方法创建addon
 		_, err = cli.CreateAddon(&eks.CreateAddonInput{
-			ClusterName: aws.String(info.Cluster.ClusterName), // 设置集群名称
-			AddonName:   aws.String(addon),                    // 设置要创建的addon名称
+			ClusterName: aws.String(info.Cluster.SystemID), // 设置集群名称
+			AddonName:   aws.String(addon),                 // 设置要创建的addon名称
 		})
 		// 如果创建addon失败，则直接返回错误
 		if err != nil {

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createNodeGroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createNodeGroup.go
@@ -15,6 +15,7 @@ package tasks
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -340,10 +341,21 @@ func CheckCloudNodeGroupStatusTask(taskID string, stepName string) error { // no
 	err = cloudprovider.GetStorageModel().UpdateNodeGroup(context.Background(),
 		generateNodeGroupFromAsgAndLtv(dependInfo.NodeGroup, asgInfo, ltvInfo))
 	if err != nil {
-		blog.Errorf("CreateCloudNodeGroupTask[%s]: UpdateNodeGroup[%s] in task %s step %s failed, %s",
+		blog.Errorf("CheckCloudNodeGroupStatusTask[%s]: UpdateNodeGroup[%s] in task %s step %s failed, %s",
 			taskID, nodeGroupID, taskID, stepName, err.Error())
-		retErr := fmt.Errorf("call CreateCloudNodeGroupTask UpdateNodeGroup[%s] api err, %s", nodeGroupID,
+		retErr := fmt.Errorf("call UpdateNodeGroup[%s] api err, %s", nodeGroupID,
 			err.Error())
+		_ = state.UpdateStepFailure(start, stepName, retErr)
+		return retErr
+	}
+
+	// delete nodegroup auto scaling group lifecycle hook
+	// 由于创建节点池后会自动创建了生命周期钩子，导致缩容删除节点池最后一个节点的时候会很慢，因此这里先删除生命周期钩子
+	// https://docs.aws.amazon.com/zh_cn/autoscaling/ec2/userguide/lifecycle-hooks.html
+	err = deleteNodegroupLifecycleHook(ctx, dependInfo, asgInfo)
+	if err != nil {
+		blog.Errorf("CheckCloudNodeGroupStatusTask[%s]: deleteNodegroupLifecycleHook failed: %v", taskID, err)
+		retErr := fmt.Errorf("deleteNodegroupLifecycleHook failed, %s", err.Error())
 		_ = state.UpdateStepFailure(start, stepName, retErr)
 		return retErr
 	}
@@ -430,6 +442,49 @@ func checkNodegroupStatus(rootCtx context.Context, dependInfo *cloudprovider.Clo
 	}
 
 	return asgInfo[0], ltvInfo, nil
+}
+
+func deleteNodegroupLifecycleHook(ctx context.Context, dependInfo *cloudprovider.CloudDependBasicInfo,
+	asInfo *autoscaling.Group) error {
+	taskID := cloudprovider.GetTaskIDFromContext(ctx)
+
+	client, err := api.NewAutoScalingClient(dependInfo.CmOption)
+	if err != nil {
+		blog.Errorf("taskID[%s] checkNodegroupStatus get aws clientSet failed, %s", taskID, err.Error())
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+	defer cancel()
+	err = loop.LoopDoFunc(ctx, func() error {
+		hooks, dErr := client.DescribeLifecycleHooks(asInfo.AutoScalingGroupName)
+		if dErr != nil {
+			blog.Errorf("taskID[%s] deleteAsLifecycleHooks failed: %v", taskID, dErr)
+			return dErr
+		}
+
+		if len(hooks) == 0 {
+			return nil
+		}
+
+		data := make([]string, 0)
+		for _, hook := range hooks {
+			data = append(data, *hook.LifecycleHookName)
+		}
+
+		dErr = client.DeleteLifecycleHooks(asInfo.AutoScalingGroupName, data)
+		if dErr != nil {
+			return dErr
+		}
+
+		return loop.EndLoop
+	}, loop.LoopInterval(5*time.Second))
+
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	return nil
 }
 
 // get Asg And Ltv

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/nodegroup.go
@@ -560,7 +560,7 @@ func (ng *NodeGroup) CheckResourcePoolQuota(group *proto.NodeGroup, scaleUpNum u
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup,
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup,
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 	return nil, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
@@ -107,8 +107,13 @@ func (vm *VPCManager) ListSubnets(vpcID, zone string, opt *cloudprovider.ListNet
 	result := make([]*proto.Subnet, 0)
 	for _, v := range subnets {
 		var cidr string
-		if v.Properties != nil && v.Properties.AddressPrefix != nil {
-			cidr = *v.Properties.AddressPrefix
+		if v.Properties != nil {
+			// AddressPrefix有可能为空，需要在AddressPrefixes获取
+			if v.Properties.AddressPrefix != nil && *v.Properties.AddressPrefix != "" {
+				cidr = *v.Properties.AddressPrefix
+			} else if len(v.Properties.AddressPrefixes) > 0 {
+				cidr = *v.Properties.AddressPrefixes[0]
+			}
 		}
 
 		result = append(result, &proto.Subnet{

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/blueking/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/blueking/nodegroup.go
@@ -320,7 +320,7 @@ func (ng *NodeGroup) CheckResourcePoolQuota(group *proto.NodeGroup, scaleUpNum u
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup,
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup,
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 	return nil, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/common/component.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/common/component.go
@@ -647,7 +647,7 @@ const (
 	defaultReplicas = 1
 )
 
-func getClusterNodeGroups(clusterID string) ([]proto.NodeGroup, error) {
+func getClusterNodeGroups(clusterID string) ([]*proto.NodeGroup, error) {
 	// get cluster nodegroup list
 	cond := &operator.Condition{
 		Op: operator.Eq,
@@ -663,7 +663,7 @@ func getClusterNodeGroups(clusterID string) ([]proto.NodeGroup, error) {
 	}
 
 	// filter status deleting node group
-	filterGroups := make([]proto.NodeGroup, 0)
+	filterGroups := make([]*proto.NodeGroup, 0)
 	for _, group := range nodegroupList {
 		if group.Status == common.StatusDeleteNodeGroupDeleting {
 			continue
@@ -731,7 +731,7 @@ func EnsureAutoScalerTask(taskID string, stepName string) error {
 	return nil
 }
 
-func ensureAutoScalerWithInstaller(ctx context.Context, nodeGroups []proto.NodeGroup, // nolint
+func ensureAutoScalerWithInstaller(ctx context.Context, nodeGroups []*proto.NodeGroup, // nolint
 	as *proto.ClusterAutoScalingOption) error {
 	taskID, stepName := cloudprovider.GetTaskIDAndStepNameFromContext(ctx)
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/common/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/common/utils.go
@@ -644,10 +644,13 @@ func UpdateClusterNodesLabels(ctx context.Context, data NodeLabelsData) error { 
 	}
 
 	for _, node := range nodeNames {
-		// user defined labels
-		labels := data.Labels
-		if labels == nil {
-			labels = make(map[string]string)
+		blog.Infof("UpdateClusterNodesLabels[%s] node[%s] ip[%s] before labels: %v",
+			taskID, node.NodeName, node.NodeIP, node.NodeLabels)
+
+		// user defined labels 深拷贝本地标签配置
+		labels := make(map[string]string)
+		for k, v := range labels {
+			labels[k] = v
 		}
 
 		// cmdb labels

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/component/autoscaler/values.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/component/autoscaler/values.go
@@ -158,7 +158,7 @@ type AutoScalerValues struct { // nolint
 // AutoScaler component paras
 type AutoScaler struct {
 	// NodeGroups cluster nodeGroup list
-	NodeGroups []cmproto.NodeGroup
+	NodeGroups []*cmproto.NodeGroup
 	// AutoScalingOption autoScaling deploy paras
 	AutoScalingOption *cmproto.ClusterAutoScalingOption
 	// Replicas

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/api/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/api/utils.go
@@ -214,9 +214,6 @@ func GenerateNodePool(input *CreateNodePoolRequest) *container.NodePool {
 		Name:             input.NodePool.Name,
 		InitialNodeCount: input.NodePool.InitialNodeCount,
 		Locations:        input.NodePool.Locations,
-		MaxPodsConstraint: &container.MaxPodsConstraint{
-			MaxPodsPerNode: input.NodePool.MaxPodsConstraint.MaxPodsPerNode,
-		},
 		Autoscaling: &container.NodePoolAutoscaling{
 			Enabled: false,
 		},
@@ -246,6 +243,12 @@ func GenerateNodePool(input *CreateNodePoolRequest) *container.NodePool {
 		nodePool.Management = &container.NodeManagement{
 			AutoRepair:  input.NodePool.Management.AutoRepair,
 			AutoUpgrade: input.NodePool.Management.AutoUpgrade,
+		}
+	}
+
+	if input.NodePool.MaxPodsConstraint.MaxPodsPerNode > 0 {
+		nodePool.MaxPodsConstraint = &container.MaxPodsConstraint{
+			MaxPodsPerNode: input.NodePool.MaxPodsConstraint.MaxPodsPerNode,
 		}
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/cloud.go
@@ -88,6 +88,11 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *cmproto.Cluster,
 	}
 	cls.KubeConfig = kubeConfig
 
+	// gke集群是否启用autopilot
+	if cluster.Autopilot.Enabled {
+		cls.ManageType = common.ClusterManageTypeManaged
+	}
+
 	// cluster cloud basic setting
 	clusterBasicSettingByGKE(cls, cluster, opt)
 	// cluster cloud network setting

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/nodegroup.go
@@ -413,7 +413,7 @@ func (ng *NodeGroup) CheckResourcePoolQuota(group *proto.NodeGroup, scaleUpNum u
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup,
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup,
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 	return nil, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createCluster.go
@@ -303,8 +303,10 @@ func generateCreateClusterRequest(info *cloudprovider.CloudDependBasicInfo, // n
 // generateCreateClusterNodePoolInput generate create node pool input
 func generateCreateClusterNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster) *api.CreateNodePoolRequest {
 	if group.NodeTemplate.MaxPodsPerNode == 0 {
-		group.NodeTemplate.MaxPodsPerNode = 110
+		// 节点池不指定最大 Pods 限制时，使用集群默认值
+		group.NodeTemplate.MaxPodsPerNode = cluster.NetworkSettings.MaxNodePodNum
 	}
+
 	return &api.CreateNodePoolRequest{
 		NodePool: &api.NodePool{
 			// gke nodePool名称中不允许有大写字母

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createNodeGroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createNodeGroup.go
@@ -129,10 +129,7 @@ func createGKENodeGroup(cmOption *cloudprovider.CommonOption, group *proto.NodeG
 
 // generateCreateNodePoolInput generate create node pool input
 func generateCreateNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster) *api.CreateNodePoolRequest {
-	if group.NodeTemplate.MaxPodsPerNode == 0 {
-		group.NodeTemplate.MaxPodsPerNode = 110
-	}
-	return &api.CreateNodePoolRequest{
+	req := &api.CreateNodePoolRequest{
 		NodePool: &api.NodePool{
 			// gke nodePool名称中不允许有大写字母
 			Name:             group.CloudNodeGroupID,
@@ -140,7 +137,7 @@ func generateCreateNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster)
 			InitialNodeCount: int64(group.AutoScaling.DesiredSize),
 			Locations:        group.AutoScaling.Zones,
 			MaxPodsConstraint: &api.MaxPodsConstraint{
-				MaxPodsPerNode: int64(group.NodeTemplate.MaxPodsPerNode),
+				MaxPodsPerNode: 0,
 			},
 			Autoscaling: &api.NodePoolAutoscaling{
 				// 不开启谷歌云 CA 组件，因为需要部署 BCS 自己的 CA 组件
@@ -149,6 +146,13 @@ func generateCreateNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster)
 			Management: generateNodeManagement(group, cluster),
 		},
 	}
+
+	// 如果节点池不指定最大 Pods 限制时，gke会使用集群默认值
+	if group.NodeTemplate.MaxPodsPerNode > 0 {
+		req.NodePool.MaxPodsConstraint.MaxPodsPerNode = int64(group.NodeTemplate.MaxPodsPerNode)
+	}
+
+	return req
 }
 
 // CheckCloudNodeGroupStatusTask check cloud node group status task

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/deleteCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/deleteCluster.go
@@ -15,6 +15,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
@@ -64,7 +65,7 @@ func DeleteGKEClusterTask(taskID string, stepName string) error {
 
 	if basicInfo.Cluster.SystemID != "" {
 		err = cli.DeleteCluster(context.Background(), basicInfo.Cluster.SystemID)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "Not found") {
 			blog.Errorf("DeleteGKEClusterTask[%s]: call google DeleteGKECluster failed: %v",
 				taskID, err)
 			retErr := fmt.Errorf("call google DeleteGKECluster failed: %s", err.Error())

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/huawei/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/huawei/nodegroup.go
@@ -384,7 +384,7 @@ func (ng *NodeGroup) CheckResourcePoolQuota(group *proto.NodeGroup, scaleUpNum u
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup,
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup,
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 	return nil, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/huawei/tasks/updateDesiredNodes.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/huawei/tasks/updateDesiredNodes.go
@@ -280,7 +280,7 @@ func transInstancesToNode(ctx context.Context, instances []model.Node, info *clo
 	taskID := cloudprovider.GetTaskIDFromContext(ctx)
 
 	for _, v := range instances {
-		node := proto.Node{}
+		node := &proto.Node{}
 		node.NodeID = *v.Metadata.Uid
 		node.InstanceType = v.Spec.Flavor
 		node.Region = info.CmOption.Region
@@ -294,7 +294,7 @@ func transInstancesToNode(ctx context.Context, instances []model.Node, info *clo
 		blog.Infof("ApplyInstanceMachinesTask[%s]: call transInstancesToNode successful. node: %#v", node)
 		blog.Infof("ApplyInstanceMachinesTask[%s]: call transInstancesToNode successful. node.server: %#v", *v.Status)
 
-		err = cloudprovider.SaveNodeInfoToDB(ctx, &node, false)
+		err = cloudprovider.SaveNodeInfoToDB(ctx, node, false)
 		if err != nil {
 			blog.Errorf("transInstancesToNode[%s] SaveNodeInfoToDB[%s] failed: %v", taskID, node.InnerIP, err)
 		}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/interface.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/interface.go
@@ -419,7 +419,7 @@ type NodeGroupManager interface {
 	GetExternalNodeScript(group *proto.NodeGroup, internal bool) (string, error)
 
 	// GetProjectCaResourceQuota get project autoscaler quota
-	GetProjectCaResourceQuota(groups []proto.NodeGroup, opt *CommonOption) ([]*proto.ProjectAutoscalerQuota, error)
+	GetProjectCaResourceQuota(groups []*proto.NodeGroup, opt *CommonOption) ([]*proto.ProjectAutoscalerQuota, error)
 }
 
 // VPCManager cloud interface for vpc management

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/ladder/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/ladder/nodegroup.go
@@ -371,12 +371,12 @@ func (ng *NodeGroup) SwitchAutoScalingOptionStatus(scalingOption *proto.ClusterA
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup, // nolint
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup, // nolint
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 
 	// 仅统计CA云梯资源 & 获取项目下所有节点池的资源使用情况 & 资源quota情况
 
-	filterGroups := make([]proto.NodeGroup, 0)
+	filterGroups := make([]*proto.NodeGroup, 0)
 	// filter yunti ca nodeGroup
 	for i := range groups {
 		if !utils.StringInSlice(groups[i].GetNodeGroupType(), []string{common.Normal.String(), ""}) {
@@ -409,7 +409,7 @@ func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup, // noli
 	for i := range filterGroups {
 		barrier.Add(1)
 
-		go func(group proto.NodeGroup) {
+		go func(group *proto.NodeGroup) {
 			defer barrier.Done()
 
 			// 地域-机型 维度的 资源池 和 可用区列表
@@ -496,7 +496,7 @@ func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup, // noli
 	return projectQuotas, nil
 }
 
-func matchProjectAutoscalerQuotaByGroup(groups []proto.NodeGroup, projectQuota *proto.ProjectAutoscalerQuota) {
+func matchProjectAutoscalerQuotaByGroup(groups []*proto.NodeGroup, projectQuota *proto.ProjectAutoscalerQuota) {
 	if projectQuota.GetTotalGroupIds() == nil {
 		projectQuota.TotalGroupIds = make([]string, 0)
 	}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/notify.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/notify.go
@@ -78,7 +78,7 @@ func SendUserNotifyByTemplates(clsId, groupId, taskId string, isSuccess bool) er
 }
 
 func sendNotifyMessage(cluster *proto.Cluster, group *proto.NodeGroup, task *proto.Task, // nolint
-	nt proto.NotifyTemplate, isSuccess bool) error {
+	nt *proto.NotifyTemplate, isSuccess bool) error {
 	if !nt.GetEnable() {
 		return fmt.Errorf("task[%s] notifyTemplate[%s] not enable", task.TaskID, nt.NotifyTemplateID)
 	}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud-public/nodegroupmgr.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud-public/nodegroupmgr.go
@@ -916,7 +916,7 @@ func (ng *NodeGroup) CheckResourcePoolQuota(group *proto.NodeGroup, scaleUpNum u
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup,
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup,
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 	return nil, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/api/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/api/utils.go
@@ -681,10 +681,6 @@ func MapToTags(tags map[string]string) []*Tag {
 
 // MapToCloudLabels converts a map of string-string to a slice of Label
 func MapToCloudLabels(labels map[string]string) []*tke.Label {
-	if len(labels) == 0 {
-		return nil
-	}
-
 	result := make([]*tke.Label, 0)
 	for k, v := range labels {
 		name := k
@@ -696,10 +692,6 @@ func MapToCloudLabels(labels map[string]string) []*tke.Label {
 
 // MapToCloudTaints converts a map of string-string to a slice of Taint
 func MapToCloudTaints(taints []*proto.Taint) []*tke.Taint {
-	if len(taints) == 0 {
-		return nil
-	}
-
 	result := make([]*tke.Taint, 0)
 	for _, v := range taints {
 		key := v.Key
@@ -712,10 +704,6 @@ func MapToCloudTaints(taints []*proto.Taint) []*tke.Taint {
 
 // MapToCloudTags converts a map of string-string to a slice of Tag
 func MapToCloudTags(tags map[string]string) []*tke.Tag {
-	if len(tags) == 0 {
-		return nil
-	}
-
 	result := make([]*tke.Tag, 0)
 	for k, v := range tags {
 		key := k

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/business/tke.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/business/tke.go
@@ -124,7 +124,7 @@ type ZoneSubnetRatio struct {
 }
 
 // GetClusterCurrentVpcCniSubnets get tke cluster subnets
-func GetClusterCurrentVpcCniSubnets(cls proto.Cluster, extraIp bool) (map[string]*ZoneSubnetRatio,
+func GetClusterCurrentVpcCniSubnets(cls *proto.Cluster, extraIp bool) (map[string]*ZoneSubnetRatio,
 	float64, []string, error) {
 	cmOption, err := cloudprovider.GetCloudCmOptionByCluster(cls)
 	if err != nil {

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/clustermgr.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/clustermgr.go
@@ -803,7 +803,7 @@ func (c *Cluster) AddSubnetsToCluster(ctx context.Context, subnet *proto.SubnetS
 	}
 
 	// 检测当前集群子网资源使用率, 如果使用率达标则继续扩容, 不达标则拒绝扩容
-	zoneSubnetRatio, _, _, err := business.GetClusterCurrentVpcCniSubnets(*opt.Cluster, false)
+	zoneSubnetRatio, _, _, err := business.GetClusterCurrentVpcCniSubnets(opt.Cluster, false)
 	if err != nil {
 		return fmt.Errorf("AddSubnetsToCluster failed: %v", err)
 	}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/nodegroupmgr.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/nodegroupmgr.go
@@ -923,7 +923,7 @@ func (ng *NodeGroup) CheckResourcePoolQuota(group *proto.NodeGroup, scaleUpNum u
 }
 
 // GetProjectCaResourceQuota get project ca resource quota
-func (ng *NodeGroup) GetProjectCaResourceQuota(groups []proto.NodeGroup,
+func (ng *NodeGroup) GetProjectCaResourceQuota(groups []*proto.NodeGroup,
 	opt *cloudprovider.CommonOption) ([]*proto.ProjectAutoscalerQuota, error) {
 	return nil, nil
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/vpcmgr.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/vpcmgr.go
@@ -261,7 +261,7 @@ func (c *VPCManager) GetClusterIpUsage(clusterId string, ipType string, opt *clo
 	case common.ClusterOverlayNetwork:
 		return business.GetClusterGrIPSurplus(opt, "", cls.GetSystemID())
 	case common.ClusterUnderlayNetwork:
-		zoneSubs, _, _, errLocal := business.GetClusterCurrentVpcCniSubnets(*cls, false)
+		zoneSubs, _, _, errLocal := business.GetClusterCurrentVpcCniSubnets(cls, false)
 		if errLocal != nil {
 			return 0, 0, err
 		}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/utils.go
@@ -213,7 +213,7 @@ func GetCredential(data *CredentialData) (*CommonOption, error) {
 }
 
 // GetCloudCmOptionByCluster get common option by cluster
-func GetCloudCmOptionByCluster(cls proto.Cluster) (*CommonOption, error) {
+func GetCloudCmOptionByCluster(cls *proto.Cluster) (*CommonOption, error) {
 	cloud, err := GetStorageModel().GetCloud(context.Background(), cls.GetProvider())
 	if err != nil {
 		blog.Errorf("GetCloudCmOptionByCluster[%s:%s] get cloud failed: %v",
@@ -1427,7 +1427,7 @@ func GetNetworkResourceGroup(cls *proto.Cluster) string {
 }
 
 // ListProjectNotifyTemplates list project notify templates
-func ListProjectNotifyTemplates(projectId string) ([]proto.NotifyTemplate, error) {
+func ListProjectNotifyTemplates(projectId string) ([]*proto.NotifyTemplate, error) {
 	condM := make(operator.M)
 	condM["projectid"] = projectId
 

--- a/bcs-services/bcs-cluster-manager/internal/daemon/azure_taint.go
+++ b/bcs-services/bcs-cluster-manager/internal/daemon/azure_taint.go
@@ -64,7 +64,7 @@ func (d *Daemon) removeAzureClusterPlatformTaints(error chan<- error) {
 
 	for i := range azureClusterList {
 		concurency.Add(1)
-		go func(cls cmproto.Cluster) {
+		go func(cls *cmproto.Cluster) {
 			defer concurency.Done()
 
 			connect := ConnectToCluster(d.model, cls.ClusterID)

--- a/bcs-services/bcs-cluster-manager/internal/daemon/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/daemon/cluster.go
@@ -41,7 +41,7 @@ func (d *Daemon) reportClusterGroupNodeNum(error chan<- error) {
 
 	for i := range groupList {
 		concurency.Add(1)
-		go func(group cmproto.NodeGroup) {
+		go func(group *cmproto.NodeGroup) {
 			defer concurency.Done()
 
 			if group.LaunchTemplate == nil || group.LaunchTemplate.InstanceType == "" {

--- a/bcs-services/bcs-cluster-manager/internal/daemon/cluster_helath.go
+++ b/bcs-services/bcs-cluster-manager/internal/daemon/cluster_helath.go
@@ -58,7 +58,7 @@ func (d *Daemon) reportClusterHealthStatus(error chan<- error) {
 		}
 
 		concurency.Add(1)
-		go func(cls cmproto.Cluster) {
+		go func(cls *cmproto.Cluster) {
 			defer concurency.Done()
 
 			newCluster, errLocal := d.model.GetCluster(d.ctx, cls.GetClusterID())

--- a/bcs-services/bcs-cluster-manager/internal/daemon/node_group.go
+++ b/bcs-services/bcs-cluster-manager/internal/daemon/node_group.go
@@ -29,8 +29,8 @@ import (
 )
 
 // GetNodeGroups get cluster node groups && check yunti groups
-func GetNodeGroups(model store.ClusterManagerModel) ([]cmproto.NodeGroup,
-	[]cmproto.NodeGroup, []cmproto.NodeGroup, error) {
+func GetNodeGroups(model store.ClusterManagerModel) ([]*cmproto.NodeGroup,
+	[]*cmproto.NodeGroup, []*cmproto.NodeGroup, error) {
 	condGroup := operator.NewLeafCondition(operator.Eq, operator.M{
 		"status": common.StatusRunning,
 	})
@@ -40,8 +40,8 @@ func GetNodeGroups(model store.ClusterManagerModel) ([]cmproto.NodeGroup,
 		return nil, nil, nil, err
 	}
 
-	var normalYunti, normalSelf, crSelf, external = make([]cmproto.NodeGroup, 0), make([]cmproto.NodeGroup, 0),
-		make([]cmproto.NodeGroup, 0), make([]cmproto.NodeGroup, 0)
+	var normalYunti, normalSelf, crSelf, external = make([]*cmproto.NodeGroup, 0), make([]*cmproto.NodeGroup, 0),
+		make([]*cmproto.NodeGroup, 0), make([]*cmproto.NodeGroup, 0)
 
 	for _, group := range groupList {
 		switch group.NodeGroupType {
@@ -90,13 +90,13 @@ func GetNodeGroups(model store.ClusterManagerModel) ([]cmproto.NodeGroup,
 
 // FilterGroupsByRegionInsType filter region instanceType nodeGroup
 func FilterGroupsByRegionInsType(model store.ClusterManagerModel, region,
-	instanceType string) ([]cmproto.NodeGroup, error) {
+	instanceType string) ([]*cmproto.NodeGroup, error) {
 	normalYunti, _, _, err := GetNodeGroups(model)
 	if err != nil {
 		return nil, err
 	}
 
-	filterGroups := make([]cmproto.NodeGroup, 0)
+	filterGroups := make([]*cmproto.NodeGroup, 0)
 	for _, group := range normalYunti {
 		if group.Region == region && group.GetLaunchTemplate().GetInstanceType() == instanceType {
 			filterGroups = append(filterGroups, group)

--- a/bcs-services/bcs-cluster-manager/internal/daemon/vpc.go
+++ b/bcs-services/bcs-cluster-manager/internal/daemon/vpc.go
@@ -33,7 +33,7 @@ const (
 	ratio  = "ratio"
 )
 
-func getIpUsageByVpc(model store.ClusterManagerModel, ipType string, vpc cmproto.CloudVPC) (uint32, uint32, error) {
+func getIpUsageByVpc(model store.ClusterManagerModel, ipType string, vpc *cmproto.CloudVPC) (uint32, uint32, error) {
 	cloud, err := actions.GetCloudByCloudID(model, vpc.CloudID)
 	if err != nil {
 		blog.Errorf("getIpUsageByVpc[%s:%s] failed: %v", vpc.Region, vpc.VpcID, err)
@@ -61,7 +61,7 @@ func getIpUsageByVpc(model store.ClusterManagerModel, ipType string, vpc cmproto
 	return vpcMgr.GetVpcIpUsage(vpc.VpcID, ipType, nil, cmOption)
 }
 
-func getIpUsageByCluster(model store.ClusterManagerModel, ipType string, cluster cmproto.Cluster) (uint32,
+func getIpUsageByCluster(model store.ClusterManagerModel, ipType string, cluster *cmproto.Cluster) (uint32,
 	uint32, error) {
 	cloud, err := actions.GetCloudByCloudID(model, cluster.GetProvider())
 	if err != nil {
@@ -103,7 +103,7 @@ func (d *Daemon) reportVpcIpResourceUsage(error chan<- error) {
 
 	for i := range cloudVPCs {
 		concurency.Add(1)
-		go func(vpc cmproto.CloudVPC) {
+		go func(vpc *cmproto.CloudVPC) {
 			defer concurency.Done()
 
 			overlayTotal, overlaySurplus, errGet := getIpUsageByVpc(d.model, common.ClusterOverlayNetwork, vpc)

--- a/bcs-services/bcs-cluster-manager/internal/store/account/account.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/account/account.go
@@ -175,8 +175,8 @@ func (m *ModelCloudAccount) GetCloudAccount(ctx context.Context,
 
 // ListCloudAccount list cloudAccount
 func (m *ModelCloudAccount) ListCloudAccount(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.CloudAccount, error) {
-	cloudAccountList := make([]types.CloudAccount, 0)
+	[]*types.CloudAccount, error) {
+	cloudAccountList := make([]*types.CloudAccount, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/cloud/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/cloud/cloud.go
@@ -184,8 +184,8 @@ func (m *ModelCloud) GetCloudByProvider(ctx context.Context, provider string) (*
 
 // ListCloud list clusters
 func (m *ModelCloud) ListCloud(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.Cloud, error) {
-	cloudList := make([]types.Cloud, 0)
+	[]*types.Cloud, error) {
+	cloudList := make([]*types.Cloud, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/cloudvpc/cloudvpc.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/cloudvpc/cloudvpc.go
@@ -150,8 +150,8 @@ func (m *ModelCloudVPC) GetCloudVPC(ctx context.Context, cloudID, vpcID string) 
 
 // ListCloudVPC list cloudVPC
 func (m *ModelCloudVPC) ListCloudVPC(ctx context.Context, vpc *operator.Condition, opt *options.ListOption) (
-	[]types.CloudVPC, error) {
-	cloudVPCList := make([]types.CloudVPC, 0)
+	[]*types.CloudVPC, error) {
+	cloudVPCList := make([]*types.CloudVPC, 0)
 	finder := m.db.Table(m.tableName).Find(vpc)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/cluster/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/cluster/cluster.go
@@ -146,8 +146,8 @@ func (m *ModelCluster) GetCluster(ctx context.Context, clusterID string) (*types
 
 // ListCluster list clusters
 func (m *ModelCluster) ListCluster(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.Cluster, error) {
-	retClusterList := make([]types.Cluster, 0)
+	[]*types.Cluster, error) {
+	retClusterList := make([]*types.Cluster, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/clustercredential/clustercredential.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/clustercredential/clustercredential.go
@@ -137,8 +137,8 @@ func (m *ModelClusterCredential) GetClusterCredential(ctx context.Context, serve
 // ListClusterCredential list online clusters
 func (m *ModelClusterCredential) ListClusterCredential(ctx context.Context, cond *operator.Condition,
 	opt *options.ListOption) (
-	[]types.ClusterCredential, error) {
-	retClusterCredentialList := make([]types.ClusterCredential, 0)
+	[]*types.ClusterCredential, error) {
+	retClusterCredentialList := make([]*types.ClusterCredential, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/moduleflag/moduleflag.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/moduleflag/moduleflag.go
@@ -168,8 +168,8 @@ func (m *ModelCloudModuleFlag) GetCloudModuleFlag(ctx context.Context, cloudID, 
 // ListCloudModuleFlag list cloud moduleFlag
 func (m *ModelCloudModuleFlag) ListCloudModuleFlag(ctx context.Context, cond *operator.Condition,
 	opt *options.ListOption) (
-	[]types.CloudModuleFlag, error) {
-	retFlagList := make([]types.CloudModuleFlag, 0)
+	[]*types.CloudModuleFlag, error) {
+	retFlagList := make([]*types.CloudModuleFlag, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/namespace/namespace.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/namespace/namespace.go
@@ -150,8 +150,8 @@ func (m *ModelNamespace) GetNamespace(ctx context.Context, name, federationClust
 
 // ListNamespace list clusters
 func (m *ModelNamespace) ListNamespace(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.Namespace, error) {
-	retNsList := make([]types.Namespace, 0)
+	[]*types.Namespace, error) {
+	retNsList := make([]*types.Namespace, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/nodegroup/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/nodegroup/nodegroup.go
@@ -159,8 +159,8 @@ func (m *ModelNodeGroup) GetNodeGroup(ctx context.Context, nodeGroupID string) (
 
 // ListNodeGroup list clusters
 func (m *ModelNodeGroup) ListNodeGroup(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.NodeGroup, error) {
-	groups := make([]types.NodeGroup, 0)
+	[]*types.NodeGroup, error) {
+	groups := make([]*types.NodeGroup, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/nodetemplate/nodetemplate.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/nodetemplate/nodetemplate.go
@@ -172,8 +172,8 @@ func (m *ModelNodeTemplate) GetNodeTemplateByID(ctx context.Context, templateID 
 
 // ListNodeTemplate list nodeTemplates
 func (m *ModelNodeTemplate) ListNodeTemplate(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.NodeTemplate, error) {
-	templateList := make([]types.NodeTemplate, 0)
+	[]*types.NodeTemplate, error) {
+	templateList := make([]*types.NodeTemplate, 0)
 
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {

--- a/bcs-services/bcs-cluster-manager/internal/store/notifytemplate/notifytemplate.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/notifytemplate/notifytemplate.go
@@ -174,8 +174,8 @@ func (m *ModelNotifyTemplate) GetNotifyTemplateByID(ctx context.Context, templat
 // ListNotifyTemplate list notifyTemplates
 func (m *ModelNotifyTemplate) ListNotifyTemplate(ctx context.Context, cond *operator.Condition,
 	opt *options.ListOption) (
-	[]types.NotifyTemplate, error) {
-	templateList := make([]types.NotifyTemplate, 0)
+	[]*types.NotifyTemplate, error) {
+	templateList := make([]*types.NotifyTemplate, 0)
 
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {

--- a/bcs-services/bcs-cluster-manager/internal/store/operationlog/operationlog.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/operationlog/operationlog.go
@@ -163,9 +163,9 @@ func (m *ModelOperationLog) DeleteOperationLogByDate(ctx context.Context, startT
 
 // ListOperationLog list logs
 func (m *ModelOperationLog) ListOperationLog(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.OperationLog, error) {
+	[]*types.OperationLog, error) {
 
-	logList := make([]types.OperationLog, 0)
+	logList := make([]*types.OperationLog, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))
@@ -199,9 +199,9 @@ func (m *ModelOperationLog) CountOperationLog(ctx context.Context, cond *operato
 // ListAggreOperationLog aggre logs
 func (m *ModelOperationLog) ListAggreOperationLog(ctx context.Context, condSrc, condDst []bson.E,
 	opt *options.ListOption) (
-	[]types.TaskOperationLog, error) {
+	[]*types.TaskOperationLog, error) {
 
-	retTaskOpLogs := make([]types.TaskOperationLog, 0)
+	retTaskOpLogs := make([]*types.TaskOperationLog, 0)
 
 	const (
 		asField = "task"

--- a/bcs-services/bcs-cluster-manager/internal/store/operationlog/tasksteplog.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/operationlog/tasksteplog.go
@@ -166,9 +166,9 @@ func (m *ModelTaskStepLog) CountTaskStepLog(ctx context.Context, cond *operator.
 
 // ListTaskStepLog list logs
 func (m *ModelTaskStepLog) ListTaskStepLog(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.TaskStepLog, error) {
+	[]*types.TaskStepLog, error) {
 
-	logList := make([]types.TaskStepLog, 0)
+	logList := make([]*types.TaskStepLog, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/project/project.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/project/project.go
@@ -146,8 +146,8 @@ func (m *ModelProject) GetProject(ctx context.Context, projectID string) (*types
 
 // ListProject list clusters
 func (m *ModelProject) ListProject(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.Project, error) {
-	projectList := make([]types.Project, 0)
+	[]*types.Project, error) {
+	projectList := make([]*types.Project, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/resourcequota/resourcequota.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/resourcequota/resourcequota.go
@@ -172,9 +172,9 @@ func (m *ModelResourceQuota) GetQuota(ctx context.Context, namespace, federation
 
 // ListQuota list clusters
 func (m *ModelResourceQuota) ListQuota(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.ResourceQuota, error) {
+	[]*types.ResourceQuota, error) {
 
-	retNsQuotaList := make([]types.ResourceQuota, 0)
+	retNsQuotaList := make([]*types.ResourceQuota, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/scalingoption/scalingoption.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/scalingoption/scalingoption.go
@@ -147,8 +147,8 @@ func (m *ModelAutoScalingOption) GetAutoScalingOption(
 // ListAutoScalingOption list cluster autoscaling option according search condition
 func (m *ModelAutoScalingOption) ListAutoScalingOption(
 	ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.ClusterAutoScalingOption, error) {
-	optionList := make([]types.ClusterAutoScalingOption, 0)
+	[]*types.ClusterAutoScalingOption, error) {
+	optionList := make([]*types.ClusterAutoScalingOption, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/store.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/store.go
@@ -58,7 +58,7 @@ type ClusterManagerModel interface {
 	UpdateCluster(ctx context.Context, cluster *types.Cluster) error
 	DeleteCluster(ctx context.Context, clusterID string) error
 	GetCluster(ctx context.Context, clusterID string) (*types.Cluster, error)
-	ListCluster(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.Cluster, error)
+	ListCluster(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.Cluster, error)
 
 	// node information storage management
 	CreateNode(ctx context.Context, node *types.Node) error
@@ -85,14 +85,14 @@ type ClusterManagerModel interface {
 	UpdateNamespace(ctx context.Context, ns *types.Namespace) error
 	DeleteNamespace(ctx context.Context, name, federationClusterID string) error
 	GetNamespace(ctx context.Context, name, federationClusterID string) (*types.Namespace, error)
-	ListNamespace(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.Namespace, error)
+	ListNamespace(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.Namespace, error)
 
 	// quota information storage management
 	CreateQuota(ctx context.Context, quota *types.ResourceQuota) error
 	UpdateQuota(ctx context.Context, quota *types.ResourceQuota) error
 	DeleteQuota(ctx context.Context, namespace, federationClusterID, clusterID string) error
 	GetQuota(ctx context.Context, namespace, federationClusterID, clusterID string) (*types.ResourceQuota, error)
-	ListQuota(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.ResourceQuota, error)
+	ListQuota(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.ResourceQuota, error)
 	BatchDeleteQuotaByCluster(ctx context.Context, clusterID string) error
 
 	// credential information storage management
@@ -100,22 +100,22 @@ type ClusterManagerModel interface {
 	GetClusterCredential(ctx context.Context, serverKey string) (*types.ClusterCredential, bool, error)
 	DeleteClusterCredential(ctx context.Context, serverKey string) error
 	ListClusterCredential(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-		[]types.ClusterCredential, error)
+		[]*types.ClusterCredential, error)
 
 	// TKE CIDR information storage management
 	CreateTkeCidr(ctx context.Context, cidr *types.TkeCidr) error
 	UpdateTkeCidr(ctx context.Context, cidr *types.TkeCidr) error
 	DeleteTkeCidr(ctx context.Context, vpc string, cidr string) error
 	GetTkeCidr(ctx context.Context, vpc string, cidr string) (*types.TkeCidr, error)
-	ListTkeCidr(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.TkeCidr, error)
-	ListTkeCidrCount(ctx context.Context, opt *options.ListOption) ([]types.TkeCidrCount, error)
+	ListTkeCidr(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.TkeCidr, error)
+	ListTkeCidrCount(ctx context.Context, opt *options.ListOption) ([]*types.TkeCidrCount, error)
 
 	// project information storage management
 	CreateProject(ctx context.Context, project *types.Project) error
 	UpdateProject(ctx context.Context, project *types.Project) error
 	DeleteProject(ctx context.Context, projectID string) error
 	GetProject(ctx context.Context, projectID string) (*types.Project, error)
-	ListProject(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.Project, error)
+	ListProject(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.Project, error)
 
 	// cloud information storage management
 	CreateCloud(ctx context.Context, cloud *types.Cloud) error
@@ -123,20 +123,20 @@ type ClusterManagerModel interface {
 	DeleteCloud(ctx context.Context, cloudID string) error
 	GetCloud(ctx context.Context, cloudID string) (*types.Cloud, error)
 	GetCloudByProvider(ctx context.Context, provider string) (*types.Cloud, error)
-	ListCloud(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.Cloud, error)
+	ListCloud(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.Cloud, error)
 
 	// cloud vpc information storage manager
 	CreateCloudVPC(ctx context.Context, vpc *types.CloudVPC) error
 	UpdateCloudVPC(ctx context.Context, vpc *types.CloudVPC) error
 	DeleteCloudVPC(ctx context.Context, cloudID string, vpcID string) error
-	ListCloudVPC(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.CloudVPC, error)
+	ListCloudVPC(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.CloudVPC, error)
 	GetCloudVPC(ctx context.Context, cloudID, vpcID string) (*types.CloudVPC, error)
 
 	// cloud account info storage manager
 	CreateCloudAccount(ctx context.Context, account *types.CloudAccount) error
 	UpdateCloudAccount(ctx context.Context, account *types.CloudAccount, skipEncrypt bool) error
 	DeleteCloudAccount(ctx context.Context, cloudID string, accountID string) error
-	ListCloudAccount(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.CloudAccount, error)
+	ListCloudAccount(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.CloudAccount, error)
 	GetCloudAccount(ctx context.Context, cloudID, accountID string, skipDecrypt bool) (*types.CloudAccount, error)
 
 	// cloud nodeTemplate info storage management
@@ -144,7 +144,7 @@ type ClusterManagerModel interface {
 	UpdateNodeTemplate(ctx context.Context, template *types.NodeTemplate) error
 	DeleteNodeTemplate(ctx context.Context, projectID string, templateID string) error
 	ListNodeTemplate(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-		[]types.NodeTemplate, error)
+		[]*types.NodeTemplate, error)
 	GetNodeTemplate(ctx context.Context, projectID, templateID string) (*types.NodeTemplate, error)
 	GetNodeTemplateByID(ctx context.Context, templateID string) (*types.NodeTemplate, error)
 
@@ -153,7 +153,7 @@ type ClusterManagerModel interface {
 	UpdateNotifyTemplate(ctx context.Context, template *types.NotifyTemplate) error
 	DeleteNotifyTemplate(ctx context.Context, projectID string, templateID string) error
 	ListNotifyTemplate(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-		[]types.NotifyTemplate, error)
+		[]*types.NotifyTemplate, error)
 	GetNotifyTemplate(ctx context.Context, projectID, templateID string) (*types.NotifyTemplate, error)
 	GetNotifyTemplateByID(ctx context.Context, templateID string) (*types.NotifyTemplate, error)
 
@@ -162,7 +162,7 @@ type ClusterManagerModel interface {
 	UpdateNodeGroup(ctx context.Context, group *types.NodeGroup) error
 	DeleteNodeGroup(ctx context.Context, groupID string) error
 	GetNodeGroup(ctx context.Context, groupID string) (*types.NodeGroup, error)
-	ListNodeGroup(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.NodeGroup, error)
+	ListNodeGroup(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.NodeGroup, error)
 	DeleteNodeGroupByClusterID(ctx context.Context, clusterID string) error
 
 	// task information storage management
@@ -171,7 +171,7 @@ type ClusterManagerModel interface {
 	PatchTask(ctx context.Context, taskID string, patchs map[string]interface{}) error
 	DeleteTask(ctx context.Context, taskID string) error
 	GetTask(ctx context.Context, taskID string) (*types.Task, error)
-	ListTask(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.Task, error)
+	ListTask(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.Task, error)
 	DeleteFinishedTaskByDate(ctx context.Context, startTime, endTime string) error
 	ListMachineryTasks(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]stypes.Task, error)
 	GetTasksFieldDistinct(ctx context.Context, fieldName string, filter interface{}) ([]string, error)
@@ -180,10 +180,10 @@ type ClusterManagerModel interface {
 	CreateOperationLog(ctx context.Context, log *types.OperationLog) error
 	DeleteOperationLogByResourceID(ctx context.Context, resourceIndex string) error
 	DeleteOperationLogByResourceType(ctx context.Context, resType string) error
-	ListOperationLog(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.OperationLog, error)
+	ListOperationLog(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.OperationLog, error)
 	CountOperationLog(ctx context.Context, cond *operator.Condition) (int64, error)
 	ListAggreOperationLog(ctx context.Context, condSrc, condDst []bson.E,
-		opt *options.ListOption) ([]types.TaskOperationLog, error)
+		opt *options.ListOption) ([]*types.TaskOperationLog, error)
 	DeleteOperationLogByDate(ctx context.Context, startTime, endTime string) error
 
 	// TaskStepLog
@@ -192,7 +192,7 @@ type ClusterManagerModel interface {
 	CreateTaskStepLogError(ctx context.Context, taskID, stepName, message string)
 	DeleteTaskStepLogByTaskID(ctx context.Context, taskID string) error
 	CountTaskStepLog(ctx context.Context, cond *operator.Condition) (int64, error)
-	ListTaskStepLog(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]types.TaskStepLog, error)
+	ListTaskStepLog(ctx context.Context, cond *operator.Condition, opt *options.ListOption) ([]*types.TaskStepLog, error)
 
 	// project information storage management
 	CreateAutoScalingOption(ctx context.Context, option *types.ClusterAutoScalingOption) error
@@ -200,7 +200,7 @@ type ClusterManagerModel interface {
 	DeleteAutoScalingOption(ctx context.Context, clusterID string) error
 	GetAutoScalingOption(ctx context.Context, clusterID string) (*types.ClusterAutoScalingOption, error)
 	ListAutoScalingOption(ctx context.Context, cond *operator.Condition,
-		opt *options.ListOption) ([]types.ClusterAutoScalingOption, error)
+		opt *options.ListOption) ([]*types.ClusterAutoScalingOption, error)
 
 	// cloudModuleFlag storage management
 	CreateCloudModuleFlag(ctx context.Context, flag *types.CloudModuleFlag) error
@@ -208,7 +208,7 @@ type ClusterManagerModel interface {
 	DeleteCloudModuleFlag(ctx context.Context, cloudID, version, module, flag string) error
 	GetCloudModuleFlag(ctx context.Context, cloudID, version, module, flag string) (*types.CloudModuleFlag, error)
 	ListCloudModuleFlag(ctx context.Context, cond *operator.Condition,
-		opt *options.ListOption) ([]types.CloudModuleFlag, error)
+		opt *options.ListOption) ([]*types.CloudModuleFlag, error)
 }
 
 // ModelSet a set of client

--- a/bcs-services/bcs-cluster-manager/internal/store/task/task.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/task/task.go
@@ -162,8 +162,8 @@ func (m *ModelTask) GetTask(ctx context.Context, taskID string) (*types.Task, er
 
 // ListTask list clusters
 func (m *ModelTask) ListTask(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.Task, error) {
-	taskList := make([]types.Task, 0)
+	[]*types.Task, error) {
+	taskList := make([]*types.Task, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))

--- a/bcs-services/bcs-cluster-manager/internal/store/tke/tke.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/tke/tke.go
@@ -155,8 +155,8 @@ func (m *ModelTkeCidr) GetTkeCidr(ctx context.Context, vpc string, cidr string) 
 
 // ListTkeCidr list tke cidr
 func (m *ModelTkeCidr) ListTkeCidr(ctx context.Context, cond *operator.Condition, opt *options.ListOption) (
-	[]types.TkeCidr, error) {
-	retTkeCidrList := make([]types.TkeCidr, 0)
+	[]*types.TkeCidr, error) {
+	retTkeCidrList := make([]*types.TkeCidr, 0)
 	finder := m.db.Table(m.tableName).Find(cond)
 	if len(opt.Sort) != 0 {
 		finder = finder.WithSort(util.MapInt2MapIf(opt.Sort))
@@ -176,8 +176,8 @@ func (m *ModelTkeCidr) ListTkeCidr(ctx context.Context, cond *operator.Condition
 }
 
 // ListTkeCidrCount list tke cidr count
-func (m *ModelTkeCidr) ListTkeCidrCount(ctx context.Context, opt *options.ListOption) ([]types.TkeCidrCount, error) {
-	retTkeCidrCountList := make([]types.TkeCidrCount, 0)
+func (m *ModelTkeCidr) ListTkeCidrCount(ctx context.Context, opt *options.ListOption) ([]*types.TkeCidrCount, error) {
+	retTkeCidrCountList := make([]*types.TkeCidrCount, 0)
 	pipeline := []map[string]interface{}{
 		{
 			"$group": map[string]interface{}{

--- a/bcs-services/bcs-cluster-manager/internal/tkehandler/tke.go
+++ b/bcs-services/bcs-cluster-manager/internal/tkehandler/tke.go
@@ -182,7 +182,7 @@ func (h *Handler) getOneTkeCidr(ctx context.Context, vpc string, ipNumber uint32
 		blog.Warnf("get one tke cidr failed, returned more than one cidr, %+v", tkeCidrs)
 		return nil, fmt.Errorf("get one tke cidr failed, returned more than one cidr")
 	}
-	return &tkeCidrs[0], nil
+	return tkeCidrs[0], nil
 }
 
 // ApplyTkeCidr assign an cidr to client


### PR DESCRIPTION
腾讯云
1. 修复更新节点池删除节点池标签和污点没同步到腾讯云端的问题 
微软云
1. 修复Azure获取集群子网列表返回的剩余IP数错误
3. 修复azure集群信息中，网络插件显示的网络类型错误的问题
4. 修复更新节点池更改为异步后，更新到Azure时获取到了旧的节点数据导致更新节点池数据失败的问题
5. 导入集群同步白名单和是否为公网的信息
6. 修复Azure集群现存单节点Pod数量上限为空的问题
谷歌云
1. 修复导入谷歌autopilot类型集群还显示弹性扩缩容选项的问题
2. 修复创建节点池如果不指定MaxPodsConstraint的时候使用集群默认MaxPodsConstraint的值
3. 修复集群在谷歌云上被删除，在bcs平台上没判断是否存在导致一直删除失败
亚马逊云
1. 修复导入集群网络插件显示为空的问题
2. 修复导入集群没同步管控区域的问题
3. 修复aws创建节点池自动生成生命周期钩子的问题，在创建节点池完成后删除生命周期钩子
5. 修复更新节点池label和taint旧的没有删除的问题
6. 修复创建集群安装默认插件传的集群id错误问题