### PR TITLE
fix: 修复腾讯云、谷歌云、亚马逊云、微软云的bug

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/actions/nodegroup/update.go
+++ b/bcs-services/bcs-cluster-manager/internal/actions/nodegroup/update.go
@@ -403,14 +403,15 @@ func (ua *UpdateAction) updateCloudNodeGroup() error {
 			)
 			return err
 		}
+		// update group info
+		if err = ua.saveNodeGroupStatus(common.StatusNodeGroupUpdating); err != nil {
+			return err
+		}
+
 		if err = taskserver.GetTaskServer().Dispatch(task); err != nil {
 			blog.Errorf("dispatch update nodegroup task for nodegroup %s failed, %s",
 				ua.group.NodeGroupID, err.Error(),
 			)
-			return err
-		}
-		// update group info
-		if err = ua.saveNodeGroupStatus(common.StatusNodeGroupUpdating); err != nil {
 			return err
 		}
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/api/as.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/api/as.go
@@ -110,3 +110,37 @@ func (as *AutoScalingClient) DetachInstances(input *autoscaling.DetachInstancesI
 
 	return output.Activities, nil
 }
+
+// DescribeLifecycleHooks list all lifecycle hooks in AutoScalingGroups
+func (as *AutoScalingClient) DescribeLifecycleHooks(asName *string) ([]*autoscaling.LifecycleHook, error) {
+	blog.Infof("DescribeLifecycleHooks asName: %s", asName)
+
+	output, err := as.asClient.DescribeLifecycleHooks(&autoscaling.DescribeLifecycleHooksInput{
+		AutoScalingGroupName: asName,
+	})
+	if err != nil {
+		blog.Errorf("DescribeLifecycleHooks failed: %v", err)
+		return nil, err
+	}
+	blog.Infof("DescribeLifecycleHooks find hooks %s", output.GoString())
+
+	return output.LifecycleHooks, nil
+}
+
+// DeleteLifecycleHooks delete lifecycle hooks in AutoScalingGroups
+func (as *AutoScalingClient) DeleteLifecycleHooks(asName *string, hookName []string) error {
+	for _, hook := range hookName {
+		_, err := as.asClient.DeleteLifecycleHook(&autoscaling.DeleteLifecycleHookInput{
+			AutoScalingGroupName: asName,
+			LifecycleHookName:    &hook,
+		})
+		if err != nil {
+			blog.Errorf("DeleteLifecycleHook failed: %s", err)
+			return err
+		}
+
+		blog.Infof("DeleteLifecycleHooks delete hooks %s successful", hook)
+	}
+
+	return nil
+}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cloud.go
@@ -114,7 +114,7 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *cmproto.Cluster,
 	}
 
 	// cluster cloud basic setting
-	clusterBasicSettingByEks(cls, cluster)
+	clusterBasicSettingByEks(cls, cluster, opt)
 
 	// cluster cloud network setting
 	clusterNetworkSettingByEks(cls, cluster, ipv4Cidr, ipv6Cidr)
@@ -122,10 +122,12 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *cmproto.Cluster,
 	return nil
 }
 
-func clusterBasicSettingByEks(cls *cmproto.Cluster, cluster *eks.Cluster) {
+func clusterBasicSettingByEks(cls *cmproto.Cluster, cluster *eks.Cluster,
+	opt *cloudprovider.SyncClusterCloudInfoOption) {
 	cls.ClusterBasicSettings = &cmproto.ClusterBasicSetting{
 		Version:     *cluster.Version,
 		VersionName: *cluster.Version,
+		Area:        opt.Area,
 	}
 	// if cluster.NodeConfig != nil {
 	// 	cls.ClusterBasicSettings.OS = cluster.NodeConfig.ImageType

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/cluster.go
@@ -174,6 +174,14 @@ func (c *Cluster) GetCluster(cloudID string, opt *cloudprovider.GetClusterOption
 		}
 	}
 
+	if opt.Cluster.ClusterAdvanceSettings.NetworkType == "" {
+		opt.Cluster.ClusterAdvanceSettings.NetworkType = common.VpcCni
+	}
+
+	if opt.Cluster.NetworkType == "" {
+		opt.Cluster.NetworkType = common.ClusterUnderlayNetwork
+	}
+
 	return opt.Cluster, nil
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/nodegroup.go
@@ -86,23 +86,33 @@ func (ng *NodeGroup) UpdateNodeGroup(
 		blog.Errorf("get cluster %s failed, %s", group.ClusterID, err.Error())
 		return nil, err
 	}
+
 	eksCli, err := api.NewEksClient(&opt.CommonOption)
 	if err != nil {
 		blog.Errorf("create eks client failed, err: %s", err.Error())
 		return nil, err
 	}
+
 	if group.NodeGroupID == "" || group.ClusterID == "" {
 		blog.Errorf("nodegroup id or cluster id is empty")
 		return nil, fmt.Errorf("nodegroup id or cluster id is empty")
 	}
-	_, err = eksCli.UpdateNodegroupConfig(ng.generateUpdateNodegroupConfigInput(group, cluster.SystemID))
+
+	cloudNg, err := eksCli.DescribeNodegroup(&group.CloudNodeGroupID, &cluster.SystemID)
+	if err != nil {
+		blog.Errorf("get cloud nodegroup failed, err: %s", err.Error())
+		return nil, err
+	}
+
+	_, err = eksCli.UpdateNodegroupConfig(ng.generateUpdateNodegroupConfigInput(group, cloudNg, cluster.SystemID))
 	if err != nil {
 		return nil, err
 	}
+
 	return nil, nil
 }
 
-func (ng *NodeGroup) generateUpdateNodegroupConfigInput(group *proto.NodeGroup,
+func (ng *NodeGroup) generateUpdateNodegroupConfigInput(group *proto.NodeGroup, cloudNg *eks.Nodegroup,
 	cluster string) *eks.UpdateNodegroupConfigInput {
 	input := &eks.UpdateNodegroupConfigInput{
 		ClusterName:   &cluster,
@@ -111,19 +121,52 @@ func (ng *NodeGroup) generateUpdateNodegroupConfigInput(group *proto.NodeGroup,
 
 	if len(group.GetNodeTemplate().GetLabels()) > 0 {
 		input.Labels = &eks.UpdateLabelsPayload{
-			AddOrUpdateLabels: aws.StringMap(group.GetNodeTemplate().GetLabels()),
+			AddOrUpdateLabels: aws.StringMap(group.NodeTemplate.Labels),
 		}
+
+		for k := range cloudNg.Labels {
+			if _, ok := group.NodeTemplate.Labels[k]; !ok {
+				input.Labels.RemoveLabels = append(input.Labels.RemoveLabels, aws.String(k))
+			}
+		}
+	} else if len(cloudNg.Labels) > 0 {
+		input.Labels = &eks.UpdateLabelsPayload{}
+		for k := range cloudNg.Labels {
+			input.Labels.RemoveLabels = append(input.Labels.RemoveLabels, aws.String(k))
+		}
+	}
+
+	if len(group.GetNodeTemplate().GetTaints()) > 0 {
+		input.Taints = &eks.UpdateTaintsPayload{
+			AddOrUpdateTaints: api.MapToAwsTaints(group.NodeTemplate.Taints),
+		}
+
+		for _, v := range cloudNg.Taints {
+			exit := false
+			for _, y := range group.NodeTemplate.Taints {
+				if *v.Key == y.Key {
+					exit = true
+					continue
+				}
+			}
+
+			if !exit {
+				input.Taints.RemoveTaints = append(input.Taints.RemoveTaints, &eks.Taint{
+					Key:    v.Key,
+					Value:  v.Value,
+					Effect: v.Effect,
+				})
+			}
+		}
+	} else if len(cloudNg.Taints) > 0 {
+		input.Taints = &eks.UpdateTaintsPayload{}
+		input.Taints.RemoveTaints = append(input.Taints.RemoveTaints, cloudNg.Taints...)
 	}
 
 	if group.AutoScaling != nil {
 		input.ScalingConfig = &eks.NodegroupScalingConfig{
 			MaxSize: aws.Int64(int64(group.AutoScaling.MaxSize)),
 			MinSize: aws.Int64(int64(group.AutoScaling.MinSize)),
-		}
-	}
-	if group.NodeTemplate != nil && group.NodeTemplate.Taints != nil {
-		input.Taints = &eks.UpdateTaintsPayload{
-			AddOrUpdateTaints: api.MapToAwsTaints(group.NodeTemplate.Taints),
 		}
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createCluster.go
@@ -379,8 +379,8 @@ func createAddon(ctx context.Context, info *cloudprovider.CloudDependBasicInfo) 
 	for _, addon := range defaultAddons {
 		// 调用CreateAddon方法创建addon
 		_, err = cli.CreateAddon(&eks.CreateAddonInput{
-			ClusterName: aws.String(info.Cluster.ClusterName), // 设置集群名称
-			AddonName:   aws.String(addon),                    // 设置要创建的addon名称
+			ClusterName: aws.String(info.Cluster.SystemID), // 设置集群名称
+			AddonName:   aws.String(addon),                 // 设置要创建的addon名称
 		})
 		// 如果创建addon失败，则直接返回错误
 		if err != nil {

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createNodeGroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/aws/tasks/createNodeGroup.go
@@ -15,6 +15,7 @@ package tasks
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -340,10 +341,21 @@ func CheckCloudNodeGroupStatusTask(taskID string, stepName string) error { // no
 	err = cloudprovider.GetStorageModel().UpdateNodeGroup(context.Background(),
 		generateNodeGroupFromAsgAndLtv(dependInfo.NodeGroup, asgInfo, ltvInfo))
 	if err != nil {
-		blog.Errorf("CreateCloudNodeGroupTask[%s]: UpdateNodeGroup[%s] in task %s step %s failed, %s",
+		blog.Errorf("CheckCloudNodeGroupStatusTask[%s]: UpdateNodeGroup[%s] in task %s step %s failed, %s",
 			taskID, nodeGroupID, taskID, stepName, err.Error())
-		retErr := fmt.Errorf("call CreateCloudNodeGroupTask UpdateNodeGroup[%s] api err, %s", nodeGroupID,
+		retErr := fmt.Errorf("call UpdateNodeGroup[%s] api err, %s", nodeGroupID,
 			err.Error())
+		_ = state.UpdateStepFailure(start, stepName, retErr)
+		return retErr
+	}
+
+	// delete nodegroup auto scaling group lifecycle hook
+	// 由于创建节点池后会自动创建了生命周期钩子，导致缩容删除节点池最后一个节点的时候会很慢，因此这里先删除生命周期钩子
+	// https://docs.aws.amazon.com/zh_cn/autoscaling/ec2/userguide/lifecycle-hooks.html
+	err = deleteNodegroupLifecycleHook(ctx, dependInfo, asgInfo)
+	if err != nil {
+		blog.Errorf("CheckCloudNodeGroupStatusTask[%s]: deleteNodegroupLifecycleHook failed: %v", taskID, err)
+		retErr := fmt.Errorf("deleteNodegroupLifecycleHook failed, %s", err.Error())
 		_ = state.UpdateStepFailure(start, stepName, retErr)
 		return retErr
 	}
@@ -430,6 +442,49 @@ func checkNodegroupStatus(rootCtx context.Context, dependInfo *cloudprovider.Clo
 	}
 
 	return asgInfo[0], ltvInfo, nil
+}
+
+func deleteNodegroupLifecycleHook(ctx context.Context, dependInfo *cloudprovider.CloudDependBasicInfo,
+	asInfo *autoscaling.Group) error {
+	taskID := cloudprovider.GetTaskIDFromContext(ctx)
+
+	client, err := api.NewAutoScalingClient(dependInfo.CmOption)
+	if err != nil {
+		blog.Errorf("taskID[%s] checkNodegroupStatus get aws clientSet failed, %s", taskID, err.Error())
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+	defer cancel()
+	err = loop.LoopDoFunc(ctx, func() error {
+		hooks, dErr := client.DescribeLifecycleHooks(asInfo.AutoScalingGroupName)
+		if dErr != nil {
+			blog.Errorf("taskID[%s] deleteAsLifecycleHooks failed: %v", taskID, dErr)
+			return dErr
+		}
+
+		if len(hooks) == 0 {
+			return nil
+		}
+
+		data := make([]string, 0)
+		for _, hook := range hooks {
+			data = append(data, *hook.LifecycleHookName)
+		}
+
+		dErr = client.DeleteLifecycleHooks(asInfo.AutoScalingGroupName, data)
+		if dErr != nil {
+			return dErr
+		}
+
+		return loop.EndLoop
+	}, loop.LoopInterval(5*time.Second))
+
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	return nil
 }
 
 // get Asg And Ltv

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
@@ -107,8 +107,13 @@ func (vm *VPCManager) ListSubnets(vpcID, zone string, opt *cloudprovider.ListNet
 	result := make([]*proto.Subnet, 0)
 	for _, v := range subnets {
 		var cidr string
-		if v.Properties != nil && v.Properties.AddressPrefix != nil {
-			cidr = *v.Properties.AddressPrefix
+		if v.Properties != nil {
+			// AddressPrefix有可能为空，需要在AddressPrefixes获取
+			if v.Properties.AddressPrefix != nil && *v.Properties.AddressPrefix != "" {
+				cidr = *v.Properties.AddressPrefix
+			} else if len(v.Properties.AddressPrefixes) > 0 {
+				cidr = *v.Properties.AddressPrefixes[0]
+			}
 		}
 
 		result = append(result, &proto.Subnet{

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/api/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/api/utils.go
@@ -214,9 +214,6 @@ func GenerateNodePool(input *CreateNodePoolRequest) *container.NodePool {
 		Name:             input.NodePool.Name,
 		InitialNodeCount: input.NodePool.InitialNodeCount,
 		Locations:        input.NodePool.Locations,
-		MaxPodsConstraint: &container.MaxPodsConstraint{
-			MaxPodsPerNode: input.NodePool.MaxPodsConstraint.MaxPodsPerNode,
-		},
 		Autoscaling: &container.NodePoolAutoscaling{
 			Enabled: false,
 		},
@@ -246,6 +243,12 @@ func GenerateNodePool(input *CreateNodePoolRequest) *container.NodePool {
 		nodePool.Management = &container.NodeManagement{
 			AutoRepair:  input.NodePool.Management.AutoRepair,
 			AutoUpgrade: input.NodePool.Management.AutoUpgrade,
+		}
+	}
+
+	if input.NodePool.MaxPodsConstraint.MaxPodsPerNode > 0 {
+		nodePool.MaxPodsConstraint = &container.MaxPodsConstraint{
+			MaxPodsPerNode: input.NodePool.MaxPodsConstraint.MaxPodsPerNode,
 		}
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/cloud.go
@@ -88,6 +88,11 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *cmproto.Cluster,
 	}
 	cls.KubeConfig = kubeConfig
 
+	// gke集群是否启用autopilot
+	if cluster.Autopilot.Enabled {
+		cls.ManageType = common.ClusterManageTypeManaged
+	}
+
 	// cluster cloud basic setting
 	clusterBasicSettingByGKE(cls, cluster, opt)
 	// cluster cloud network setting

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createCluster.go
@@ -303,8 +303,10 @@ func generateCreateClusterRequest(info *cloudprovider.CloudDependBasicInfo, // n
 // generateCreateClusterNodePoolInput generate create node pool input
 func generateCreateClusterNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster) *api.CreateNodePoolRequest {
 	if group.NodeTemplate.MaxPodsPerNode == 0 {
-		group.NodeTemplate.MaxPodsPerNode = 110
+		// 节点池不指定最大 Pods 限制时，使用集群默认值
+		group.NodeTemplate.MaxPodsPerNode = cluster.NetworkSettings.MaxNodePodNum
 	}
+
 	return &api.CreateNodePoolRequest{
 		NodePool: &api.NodePool{
 			// gke nodePool名称中不允许有大写字母

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createNodeGroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createNodeGroup.go
@@ -129,10 +129,7 @@ func createGKENodeGroup(cmOption *cloudprovider.CommonOption, group *proto.NodeG
 
 // generateCreateNodePoolInput generate create node pool input
 func generateCreateNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster) *api.CreateNodePoolRequest {
-	if group.NodeTemplate.MaxPodsPerNode == 0 {
-		group.NodeTemplate.MaxPodsPerNode = 110
-	}
-	return &api.CreateNodePoolRequest{
+	req := &api.CreateNodePoolRequest{
 		NodePool: &api.NodePool{
 			// gke nodePool名称中不允许有大写字母
 			Name:             group.CloudNodeGroupID,
@@ -140,7 +137,7 @@ func generateCreateNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster)
 			InitialNodeCount: int64(group.AutoScaling.DesiredSize),
 			Locations:        group.AutoScaling.Zones,
 			MaxPodsConstraint: &api.MaxPodsConstraint{
-				MaxPodsPerNode: int64(group.NodeTemplate.MaxPodsPerNode),
+				MaxPodsPerNode: 0,
 			},
 			Autoscaling: &api.NodePoolAutoscaling{
 				// 不开启谷歌云 CA 组件，因为需要部署 BCS 自己的 CA 组件
@@ -149,6 +146,13 @@ func generateCreateNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster)
 			Management: generateNodeManagement(group, cluster),
 		},
 	}
+
+	// 如果节点池不指定最大 Pods 限制时，gke会使用集群默认值
+	if group.NodeTemplate.MaxPodsPerNode > 0 {
+		req.NodePool.MaxPodsConstraint.MaxPodsPerNode = int64(group.NodeTemplate.MaxPodsPerNode)
+	}
+
+	return req
 }
 
 // CheckCloudNodeGroupStatusTask check cloud node group status task

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/deleteCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/deleteCluster.go
@@ -15,6 +15,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
@@ -64,7 +65,7 @@ func DeleteGKEClusterTask(taskID string, stepName string) error {
 
 	if basicInfo.Cluster.SystemID != "" {
 		err = cli.DeleteCluster(context.Background(), basicInfo.Cluster.SystemID)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "Not found") {
 			blog.Errorf("DeleteGKEClusterTask[%s]: call google DeleteGKECluster failed: %v",
 				taskID, err)
 			retErr := fmt.Errorf("call google DeleteGKECluster failed: %s", err.Error())

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/api/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/qcloud/api/utils.go
@@ -689,10 +689,6 @@ func MapToTags(tags map[string]string) []*Tag {
 
 // MapToCloudLabels converts a map of string-string to a slice of Label
 func MapToCloudLabels(labels map[string]string) []*tke.Label {
-	if len(labels) == 0 {
-		return nil
-	}
-
 	result := make([]*tke.Label, 0)
 	for k, v := range labels {
 		name := k
@@ -704,10 +700,6 @@ func MapToCloudLabels(labels map[string]string) []*tke.Label {
 
 // MapToCloudTaints converts a map of string-string to a slice of Taint
 func MapToCloudTaints(taints []*proto.Taint) []*tke.Taint {
-	if len(taints) == 0 {
-		return nil
-	}
-
 	result := make([]*tke.Taint, 0)
 	for _, v := range taints {
 		key := v.Key
@@ -720,10 +712,6 @@ func MapToCloudTaints(taints []*proto.Taint) []*tke.Taint {
 
 // MapToCloudTags converts a map of string-string to a slice of Tag
 func MapToCloudTags(tags map[string]string) []*tke.Tag {
-	if len(tags) == 0 {
-		return nil
-	}
-
 	result := make([]*tke.Tag, 0)
 	for k, v := range tags {
 		key := k


### PR DESCRIPTION
1. 修复更新节点池删除节点池标签和污点没同步到腾讯云端的问题 微软云
1. 修复Azure获取集群子网列表返回的剩余IP数错误
2. 修复azure集群信息中，网络插件显示的网络类型错误的问题
3. 修复更新节点池更改为异步后，更新到Azure时获取到了旧的节点数据导致更新节点池数据失败的问题
4. 导入集群同步白名单和是否为公网的信息
5. 修复Azure集群现存单节点Pod数量上限为空的问题 谷歌云
1. 修复导入谷歌autopilot类型集群还显示弹性扩缩容选项的问题
2. 修复创建节点池如果不指定MaxPodsConstraint的时候使用集群默认MaxPodsConstraint的值
3. 修复集群在谷歌云上被删除，在bcs平台上没判断是否存在导致一直删除失败 亚马逊云
1. 修复导入集群网络插件显示为空的问题
2. 修复导入集群没同步管控区域的问题
3. 修复aws创建节点池自动生成生命周期钩子的问题，在创建节点池完成后删除生命周期钩子
4. 修复更新节点池label和taint旧的没有删除的问题
5. 修复创建集群安装默认插件传的集群id错误问题