### PR TITLE
feat: cmdb-synchronizer删除集群补全&增加cmdb请求metrics指标

### DIFF
--- a/bcs-services/bcs-bkcmdb-synchronizer/go.mod
+++ b/bcs-services/bcs-bkcmdb-synchronizer/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/prometheus/client_golang v1.19.0
 	github.com/rabbitmq/amqp091-go v1.5.0
 	go-micro.dev/v4 v4.8.1
 	google.golang.org/grpc v1.62.1
@@ -108,7 +109,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/types.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/types.go
@@ -18,6 +18,7 @@ import (
 	"math/big"
 
 	bkcmdbkube "configcenter/src/kube/types" // nolint
+
 	pmp "github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi/bcsproject"
 	cmp "github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi/clustermanager"
 	bcsregistry "github.com/Tencent/bk-bcs/bcs-common/pkg/registry"

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/metrics/metrics.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/metrics/metrics.go
@@ -1,0 +1,57 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package metrics define metrics for cmdb synchronizer
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	// BkBcsCmdbSynchronizer metrics namespace
+	BkBcsCmdbSynchronizer = "bkbcs_cmdbsynchronizer"
+)
+
+var (
+	// CMDBRequestsTotal CMDB请求总数计数器
+	CMDBRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: BkBcsCmdbSynchronizer,
+			Name:      "cmdb_requests_total",
+			Help:      "Total number of CMDB requests",
+		},
+		[]string{"method", "endpoint", "status"},
+	)
+
+	// CMDBRequestDuration CMDB请求延迟直方图
+	CMDBRequestDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: BkBcsCmdbSynchronizer,
+			Name:      "cmdb_request_duration_seconds",
+			Help:      "CMDB request duration in seconds",
+			Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"method", "endpoint"},
+	)
+
+	// CMDBRequestsInFlight 当前正在处理的CMDB请求数
+	CMDBRequestsInFlight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: BkBcsCmdbSynchronizer,
+			Name:      "cmdb_requests_in_flight",
+			Help:      "Number of CMDB requests currently being processed",
+		},
+		[]string{"endpoint"},
+	)
+)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
@@ -24,6 +24,7 @@ type BkcmdbSynchronizerOption struct {
 	RabbitMQ      RabbitMQConfig      `json:"rabbitmq"`
 	CMDB          CMDBConfig          `json:"cmdb"`
 	SharedCluster SharedClusterConfig `json:"shared_cluster"`
+	Metrics       MetricsConfig       `json:"metrics"`
 }
 
 // SynchronizerConfig synchronizer config
@@ -75,4 +76,9 @@ type CMDBConfig struct {
 // SharedClusterConfig shared cluster config
 type SharedClusterConfig struct {
 	AnnotationKeyProjCode string `json:"annotation_key_proj_code"`
+}
+
+// MetricsConfig metrics config
+type MetricsConfig struct {
+	Port int `json:"port"`
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -2820,6 +2820,12 @@ func (s *Syncer) GetProjectManagerGrpcGwClient() (pmCli *client.ProjectManagerCl
 
 // GetBkCluster get bkcluster
 func (s *Syncer) GetBkCluster(cluster *cmp.Cluster, db *gorm.DB, withDB bool) (*bkcmdbkube.Cluster, error) {
+	// Check if cluster is nil
+	if cluster == nil {
+		blog.Errorf("cluster is nil in GetBkCluster")
+		return nil, errors.New("cluster is nil")
+	}
+
 	var clusterBkBizID int64
 	if bkBizID == 0 {
 		bizid, err := strconv.ParseInt(cluster.BusinessID, 10, 64)
@@ -5470,9 +5476,9 @@ func (s *Syncer) deleteAllByClusterCluster(bkCluster *bkcmdbkube.Cluster) error 
 					Condition: "AND",
 					Rules: []client.Rule{
 						{
-							Field: "id",
+							Field:    "id",
 							Operator: "in",
-							Value: []int64{bkCluster.ID},
+							Value:    []int64{bkCluster.ID},
 						},
 					},
 				},

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	bkcmdbkube "configcenter/src/kube/types" // nolint
+
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	"github.com/Tencent/bk-bcs/bcs-common/common/ssl"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi"
@@ -5465,6 +5466,16 @@ func (s *Syncer) deleteAllByClusterCluster(bkCluster *bkcmdbkube.Cluster) error 
 					Limit: 10,
 					Start: 0,
 				},
+				Filter: &client.PropertyFilter{
+					Condition: "AND",
+					Rules: []client.Rule{
+						{
+							Field: "id",
+							Operator: "in",
+							Value: []int64{bkCluster.ID},
+						},
+					},
+				},
 			},
 		}, nil, false)
 		if err != nil {
@@ -5501,6 +5512,16 @@ func (s *Syncer) deleteAllByClusterNode(bkCluster *bkcmdbkube.Cluster) error {
 				Page: client.Page{
 					Limit: 100,
 					Start: 0,
+				},
+				Filter: &client.PropertyFilter{
+					Condition: "AND",
+					Rules: []client.Rule{
+						{
+							Field:    "cluster_uid",
+							Operator: "in",
+							Value:    []string{bkCluster.Uid},
+						},
+					},
 				},
 			},
 		}, nil, false)
@@ -5539,6 +5560,16 @@ func (s *Syncer) deleteAllByClusterNamespace(bkCluster *bkcmdbkube.Cluster) erro
 				Page: client.Page{
 					Limit: 200,
 					Start: 0,
+				},
+				Filter: &client.PropertyFilter{
+					Condition: "AND",
+					Rules: []client.Rule{
+						{
+							Field:    "cluster_uid",
+							Operator: "in",
+							Value:    []string{bkCluster.Uid},
+						},
+					},
 				},
 			},
 		}, nil, false)


### PR DESCRIPTION
- 添加CMDB请求监控指标: 新增3个Prometheus指标
    - cmdb_requests_total: CMDB请求总数计数器，按method、endpoint、status标签分类
    - cmdb_request_duration_seconds: CMDB请求延迟直方图监控
    - cmdb_requests_in_flight: 当前处理中的CMDB请求数量
- 增加集群清理逻辑: 定时机制在扫描是否有新集群或者删除集群并开启后关闭同步之后，增加删除集群在CMDB中的数据清理操作
- 修复消息处理死锁:  解决消息处理循环中的出现的阻塞问题，出现的场景是删除集群之后bcs-k8s-watch被删除，storage停止接收消息，导致消息队列没有新的消息而阻塞，循环中无法接收到done信号而终止退出
- 修复全量同步未重新获取workList和clusterMap等，导致新集群没有进行全量同步
- 修复接口未重新获取workList和clusterMap的问题