### PR TITLE
fix: user-manager parseRedisConfig缺少masterName

### DIFF
--- a/bcs-services/bcs-user-manager/app/app.go
+++ b/bcs-services/bcs-user-manager/app/app.go
@@ -186,6 +186,7 @@ func parseRedisConfig(redisOp options.RedisConfig) (config.RedisConfig, error) {
 		return conf, fmt.Errorf("error decrypting redis config and exit: %s", err.Error())
 	}
 	conf.RedisMode = redisOp.RedisMode
+	conf.MasterName = redisOp.MasterName
 	conf.Addr = redisOp.Addr
 	conf.Password = string(redisPassword)
 	conf.DialTimeout = redisOp.DialTimeout


### PR DESCRIPTION
user-manager parseRedisConfig缺少masterName