### PR TITLE
fix: 修复禁用ipv6导致服务启动异常

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/app/app.go
+++ b/bcs-services/bcs-cluster-manager/internal/app/app.go
@@ -995,7 +995,7 @@ func (cm *ClusterManager) initMicro() error { // nolint
 	if err := dualStackListener.AddListener(ipv4, port); err != nil { // 添加主地址监听
 		return err
 	}
-	if ipv6 != ipv4 {
+	if ipv6 != "" && ipv6 != ipv4 {
 		err := dualStackListener.AddListener(ipv6, port) // 添加副地址监听
 		if err != nil {
 			return err

--- a/bcs-services/bcs-cluster-manager/main.go
+++ b/bcs-services/bcs-cluster-manager/main.go
@@ -120,7 +120,9 @@ func main() { // nolint
 	})
 
 	// init serverConfig Ipv6Address
-	opt.ServerConfig.Ipv6Address = util.InitIPv6Address(opt.ServerConfig.Ipv6Address)
+	if opt.ServerConfig.Ipv6Address != "" && opt.Address != opt.ServerConfig.Ipv6Address {
+		opt.ServerConfig.Ipv6Address = util.InitIPv6Address(opt.ServerConfig.Ipv6Address)
+	}
 	blog.Infof("service ipv6 server address: %s", opt.ServerConfig.Ipv6Address)
 
 	clusterManager := app.NewClusterManager(opt)

--- a/bcs-services/bcs-project-manager/cmd/init.go
+++ b/bcs-services/bcs-project-manager/cmd/init.go
@@ -342,8 +342,10 @@ func (p *ProjectService) initMicro() error {
 	if err := dualStackListener.AddListener(ipv4, port); err != nil {
 		return err
 	}
-	if err := dualStackListener.AddListener(ipv6, port); err != nil {
-		return err
+	if ipv6 == "" && ipv4 != ipv6 {
+		if err := dualStackListener.AddListener(ipv6, port); err != nil {
+			return err
+		}
 	}
 	// get grpc server
 	grpcServer := svc.Server()

--- a/bcs-services/bcs-project-manager/cmd/init.go
+++ b/bcs-services/bcs-project-manager/cmd/init.go
@@ -269,7 +269,7 @@ func (p *ProjectService) initPermClient() error {
 }
 
 // initMicro init micro service
-// NOCC:golint/fnsize(设计如此)
+// nolint:funlen //(设计如此)
 func (p *ProjectService) initMicro() error {
 
 	// server listen ip

--- a/bcs-services/bcs-storage/app/server.go
+++ b/bcs-services/bcs-storage/app/server.go
@@ -14,6 +14,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/Tencent/bk-bcs/bcs-common/common"
@@ -146,6 +147,10 @@ func initCert(op *options.StorageOptions) {
 		op.ClientCert.IsSSL = true
 	}
 
-	// 初始化IPv6Address字段
-	op.ServiceConfig.InitIPv6AddressFiled()
+	if op.IPv6Address == "" {
+		fmt.Printf("op.IPv6Address is empty\n")
+	} else {
+		// 初始化IPv6Address字段
+		op.ServiceConfig.InitIPv6AddressFiled()
+	}
 }

--- a/bcs-services/bcs-storage/pkg/server/server.go
+++ b/bcs-services/bcs-storage/pkg/server/server.go
@@ -87,8 +87,11 @@ func (m *MicroServer) initHTTPServer() error {
 		strconv.FormatUint(m.op.GRPCPort, 10)), grpcDialOpts); err != nil {
 		return errors.Wrapf(err, "register http gateway failed")
 	}
-
-	m.httpServer = ipv6server.NewTlsIPv6Server([]string{m.op.Address, m.op.IPv6Address},
+	addresses := []string{m.op.Address}
+	if m.op.IPv6Address != "" && m.op.Address != m.op.IPv6Address {
+		addresses = append(addresses, m.op.Address)
+	}
+	m.httpServer = ipv6server.NewTlsIPv6Server(addresses,
 		strconv.FormatUint(m.op.HttpPort, 10), "tcp", m.serverTLSConfig, gMux,
 	)
 
@@ -120,8 +123,10 @@ func (m *MicroServer) initGrpcServer() (err error) {
 	if err = dualStackListener.AddListener(ipv4, port); err != nil { // 添加IPv4地址监听
 		return errors.Wrapf(err, "add IPv4 address failed")
 	}
-	if err = dualStackListener.AddListener(ipv6, port); err != nil { // 添加IPv6地址监听
-		return errors.Wrapf(err, "add IPv6 address failed")
+	if ipv6 != "" && ipv6 != ipv4 {
+		if err = dualStackListener.AddListener(ipv6, port); err != nil { // 添加IPv6地址监听
+			return errors.Wrapf(err, "add IPv6 address failed")
+		}
 	}
 
 	// 创建go-micro服务

--- a/bcs-services/bcs-storage/storage/storage.go
+++ b/bcs-services/bcs-storage/storage/storage.go
@@ -288,7 +288,10 @@ func (s *StorageServer) close() {
 func runPrometheusMetrics(op *options.StorageOptions) {
 	http.Handle("/metrics", promhttp.Handler())
 	// ipv4 ipv6
-	ips := []string{op.Address, op.IPv6Address}
+	ips := []string{op.Address}
+	if op.IPv6Address != "" && op.IPv6Address != op.Address {
+		ips = append(ips, op.IPv6Address)
+	}
 	ipv6Server := ipv6server.NewIPv6Server(ips, strconv.Itoa(int(op.MetricPort)), "", nil)
 	// 启动server，同时监听v4、v6地址
 	// nolint

--- a/bcs-services/bcs-user-manager/app/app.go
+++ b/bcs-services/bcs-user-manager/app/app.go
@@ -15,12 +15,14 @@ package app
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/Tencent/bk-bcs/bcs-common/common"
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	"github.com/Tencent/bk-bcs/bcs-common/common/encrypt"
 	"github.com/Tencent/bk-bcs/bcs-common/common/ssl"
+	"github.com/Tencent/bk-bcs/bcs-common/common/types"
 	"github.com/Tencent/bk-bcs/bcs-common/common/util"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-user-manager/app/pkg/component"
@@ -91,7 +93,13 @@ func parseConfig(op *options.UserManagerOptions) (*config.UserMgrConfig, error) 
 	userMgrConfig := config.NewUserMgrConfig()
 
 	userMgrConfig.Address = op.Address
-	userMgrConfig.IPv6Address = util.InitIPv6Address(op.IPv6Address)
+	ipv6Address := util.InitIPv6Address(op.IPv6Address)
+	// 如果没有主动配置IPv6，同时也没有从环境变量解析出可用IPv6，则不监听IPv6地址
+	if op.IPv6Address == "" && ipv6Address == net.IPv6loopback.String() &&
+		util.GetIPv6Address(os.Getenv(types.LOCALIPV6)) == "" {
+		ipv6Address = ""
+	}
+	userMgrConfig.IPv6Address = ipv6Address
 	userMgrConfig.Port = op.Port
 	userMgrConfig.InsecureAddress = op.InsecureAddress
 	userMgrConfig.InsecurePort = op.InsecurePort


### PR DESCRIPTION
部分服务在节点禁用ipv6的情况下，bcs 部分服务，默认监听 [::1] 导致出现类似错误：socket: address family not supported by protocol，未完全兼容仅允许ipv4的情况