### PR TITLE
fix: [bcs-common ]修复 bcs-storage client 的 ListCustomResource API 路径和参数渲染问题

### DIFF
--- a/bcs-common/pkg/bcsapi/storage.go
+++ b/bcs-common/pkg/bcsapi/storage.go
@@ -795,17 +795,30 @@ func (c *StorageCli) GetIPPoolDetailInfo(clusterID string) ([]*storage.IPPool, e
 
 // ListCustomResource list custom resources, dest should be corresponding resource type or map[string]interface{}
 func (c *StorageCli) ListCustomResource(resourceType string, filter map[string]string, dest interface{}) error {
+	cluster := filter["clusterId"]
+	namespace := filter["namespace"]
+	subPath := fmt.Sprintf("/dynamic/customresources/%s?clusterId=%s", resourceType, cluster)
+	if namespace != "" {
+		subPath = fmt.Sprintf("/dynamic/customresources/%s?clusterId=%s&namespace=%s", resourceType, cluster, namespace)
+	}
+	return c.customResourceQuery(subPath, dest)
+}
+
+func (c *StorageCli) customResourceQuery(subPath string, dest interface{}) error {
+	var response BasicResponse
 	err := bkbcsSetting(c.Client.Get(), c.Config).
 		WithEndpoints(c.Config.Hosts).
-		WithBasePath("/").
-		SubPathf(customResourcePath, resourceType).
-		WithParams(filter).
+		WithBasePath(c.getRequestPath()).
+		SubPathf(subPath).
 		Do().
-		Into(dest)
+		Into(&response)
 	if err != nil {
 		return err
 	}
-	return nil
+	if !response.Result {
+		return fmt.Errorf(response.Message)
+	}
+	return json.Unmarshal(response.Data, dest)
 }
 
 // PutCustomResource put cluster resource


### PR DESCRIPTION
本次提交修复了 bcs-storage 客户端在调用 ListCustomResource 接口时路径拼接不正确、未处理 namespace 参数以及响应结果解析不完善的问题，通过引入通用的 customResourceQuery 方法统一了错误处理逻辑，显著提升了接口调用的稳定性。