### PR TITLE
feat: [bcs-common] 新增 GetK8SDeployment 和 GetK8SStatefulSet 接口

### DIFF
--- a/bcs-common/pkg/bcsapi/mock/storage_mock.go
+++ b/bcs-common/pkg/bcsapi/mock/storage_mock.go
@@ -150,6 +150,21 @@ func (mr *MockStorageMockRecorder) QueryK8SDeployment(cluster, namespace interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryK8SDeployment", reflect.TypeOf((*MockStorage)(nil).QueryK8SDeployment), cluster, namespace)
 }
 
+// GetK8SDeployment mocks base method.
+func (m *MockStorage) GetK8SDeployment(cluster, namespace, name string) (*storage.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetK8SDeployment", cluster, namespace, name)
+	ret0, _ := ret[0].(*storage.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetK8SDeployment indicates an expected call of GetK8SDeployment.
+func (mr *MockStorageMockRecorder) GetK8SDeployment(cluster, namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetK8SDeployment", reflect.TypeOf((*MockStorage)(nil).GetK8SDeployment), cluster, namespace, name)
+}
+
 // QueryK8SGameDeployment mocks base method.
 func (m *MockStorage) QueryK8SGameDeployment(cluster, namespace string) ([]*storage.GameDeployment, error) {
 	m.ctrl.T.Helper()
@@ -238,6 +253,21 @@ func (m *MockStorage) QueryK8SStatefulSet(cluster, namespace string) ([]*storage
 func (mr *MockStorageMockRecorder) QueryK8SStatefulSet(cluster, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryK8SStatefulSet", reflect.TypeOf((*MockStorage)(nil).QueryK8SStatefulSet), cluster, namespace)
+}
+
+// GetK8SStatefulSet mocks base method.
+func (m *MockStorage) GetK8SStatefulSet(cluster, namespace, name string) (*storage.StatefulSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetK8SStatefulSet", cluster, namespace, name)
+	ret0, _ := ret[0].(*storage.StatefulSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetK8SStatefulSet indicates an expected call of GetK8SStatefulSet.
+func (mr *MockStorageMockRecorder) GetK8SStatefulSet(cluster, namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetK8SStatefulSet", reflect.TypeOf((*MockStorage)(nil).GetK8SStatefulSet), cluster, namespace, name)
 }
 
 // QueryK8sGPA mocks base method.

--- a/bcs-common/pkg/bcsapi/storage.go
+++ b/bcs-common/pkg/bcsapi/storage.go
@@ -60,10 +60,14 @@ type Storage interface {
 	QueryK8SNamespace(cluster string, namespaces ...string) ([]*storage.Namespace, error)
 	// QueryK8SDeployment query all deployment in specified cluster
 	QueryK8SDeployment(cluster, namespace string) ([]*storage.Deployment, error)
+	// GetK8SDeployment query single deployment by name
+	GetK8SDeployment(cluster, namespace, name string) (*storage.Deployment, error)
 	// QueryK8SDaemonSet query all daemonset in specified cluster
 	QueryK8SDaemonSet(cluster, namespace string) ([]*storage.DaemonSet, error)
 	// QueryK8SStatefulSet query all statefulset in specified cluster
 	QueryK8SStatefulSet(cluster, namespace string) ([]*storage.StatefulSet, error)
+	// GetK8SStatefulSet query single statefulset by name
+	GetK8SStatefulSet(cluster, namespace, name string) (*storage.StatefulSet, error)
 	// QueryK8SGameDeployment query all gamedeployment in specified cluster
 	QueryK8SGameDeployment(cluster, namespace string) ([]*storage.GameDeployment, error)
 	// QueryK8SGameStatefulSet query all gamestatefulset in specified cluster
@@ -532,6 +536,27 @@ func (c *StorageCli) QueryK8SStatefulSet(cluster, namespace string) ([]*storage.
 	return statefulsets, nil
 }
 
+// GetK8SStatefulSet query single statefulset by name
+func (c *StorageCli) GetK8SStatefulSet(cluster, namespace, name string) (*storage.StatefulSet, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is empty")
+	}
+	if name == "" {
+		return nil, fmt.Errorf("name is empty")
+	}
+	subPath := "/k8s/dynamic/namespace_resources/clusters/%s/namespaces/" + namespace + "/StatefulSet/" + name
+
+	var statefulset storage.StatefulSet
+	response, err := c.query(cluster, subPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(response.Data, &statefulset); err != nil {
+		return nil, fmt.Errorf("statefulset decode err: %s", err.Error())
+	}
+	return &statefulset, nil
+}
+
 // QueryK8SDaemonSet query all daemonset in specified cluster
 func (c *StorageCli) QueryK8SDaemonSet(cluster, namespace string) ([]*storage.DaemonSet, error) {
 	if namespace == "" {
@@ -600,6 +625,27 @@ func (c *StorageCli) QueryK8SDeployment(cluster, namespace string) ([]*storage.D
 		return nil, nil
 	}
 	return deployments, nil
+}
+
+// GetK8SDeployment query single deployment by name
+func (c *StorageCli) GetK8SDeployment(cluster, namespace, name string) (*storage.Deployment, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is empty")
+	}
+	if name == "" {
+		return nil, fmt.Errorf("name is empty")
+	}
+	subPath := "/k8s/dynamic/namespace_resources/clusters/%s/namespaces/" + namespace + "/Deployment/" + name
+
+	var deployment storage.Deployment
+	response, err := c.query(cluster, subPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(response.Data, &deployment); err != nil {
+		return nil, fmt.Errorf("deployment decode err: %s", err.Error())
+	}
+	return &deployment, nil
 }
 
 // QueryK8SNamespace query all namespace in specified cluster


### PR DESCRIPTION
新增按名称精确查询单个 Deployment/StatefulSet 的接口，
通过 /k8s/dynamic/namespace_resources/clusters/:clusterId/namespaces/:namespace/:resourceType/:resourceName 路径直接获取单个资源， 避免查询整个 namespace 下的所有资源列表再遍历查找。