### PR TITLE
feat: [bcs-bkcmdb-synchronizer] 支持同步CRD

### DIFF
--- a/bcs-services/bcs-bkcmdb-synchronizer/cmd/synchronizer/main.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/cmd/synchronizer/main.go
@@ -58,6 +58,11 @@ func init() {
 		blog.Fatalf("load config failed, err: %s", err.Error())
 	}
 
+	// Parse and set custom resource types from environment variable
+	if err := common.SetCustomResourceTypesFromEnv(BkcmdbSynchronizerOption); err != nil {
+		blog.Warnf("parse custom resource types from env failed: %s, using default", err)
+	}
+
 	if err := common.DecryptCMOption(BkcmdbSynchronizerOption); err != nil {
 		blog.Fatalf("load config failed, err: %s", err.Error())
 	}

--- a/bcs-services/bcs-bkcmdb-synchronizer/config/bcs-bkcmdb-synchronizer.json.template
+++ b/bcs-services/bcs-bkcmdb-synchronizer/config/bcs-bkcmdb-synchronizer.json.template
@@ -5,7 +5,8 @@
     "bkBizID": ${synchronizer_bkBizID},
     "hostID": ${synchronizer_hostID},
     "whiteList": "${synchronizer_whiteList}",
-    "blackList": "${synchronizer_blackList}"
+    "blackList": "${synchronizer_blackList}",
+    "customResourceTypes": {}
   },
   "client": {
     "client_crt_pwd": "${client_clientCrtPwd}",

--- a/bcs-services/bcs-bkcmdb-synchronizer/go.mod
+++ b/bcs-services/bcs-bkcmdb-synchronizer/go.mod
@@ -13,7 +13,7 @@ replace (
 
 require (
 	configcenter v0.0.0-00010101000000-000000000000
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20240830030550-c83253c3a207
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20260402013426-33f9185571c1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/go-micro/plugins/v4/registry/etcd v1.1.0
 	github.com/kirito41dd/xslice v0.0.1

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/cmdb/cmdb.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/cmdb/cmdb.go
@@ -51,6 +51,8 @@ const (
 	StatefulSet = "state7efulSet"
 	// Deployment 表示部署
 	Deployment = "deployment"
+	// CustomResource 表示自定义资源
+	CustomResource = "customResource"
 	// And 表示逻辑与操作
 	And = "AND"
 	// OR 表示逻辑或操作
@@ -1373,6 +1375,23 @@ func (c *cmdbClient) GetBcsWorkload(
 					blog.Errorf("unmarshal podsWorkload failed: %v", errUM)
 				}
 			}
+		case CustomResource:
+			var customResource []model.CustomResource
+			if err := query.Debug().Find(&customResource).Error; err != nil {
+				blog.Errorf("query customResource withDB failed: %v", err)
+			} else {
+				if customResourceMarshal, errM := json.Marshal(customResource); errM != nil {
+					blog.Errorf("marshal customResource failed: %v", errM)
+				} else {
+					var bkCustomResource []interface{}
+					errUM := json.Unmarshal(customResourceMarshal, &bkCustomResource)
+					if errUM == nil {
+						blog.Infof("GetBcsWorkload customResourceWithDB get: %d", len(bkCustomResource))
+						return &bkCustomResource, nil
+					}
+					blog.Errorf("unmarshal customResource failed: %v", errUM)
+				}
+			}
 		}
 	}
 
@@ -1573,6 +1592,34 @@ func (c *cmdbClient) GetBcsWorkload(
 							} else {
 								blog.Infof("GetBcsWorkload podsWordloadWithDB update: %s.%s",
 									p.ClusterUID, p.Name)
+							}
+						}
+					}
+				}
+			case CustomResource:
+				var customResource []model.CustomResource
+				if errM := json.Unmarshal(workloadMarshal, &customResource); errM != nil {
+					blog.Errorf("unmarshal customResource failed: %v", errM)
+				} else {
+					for _, cr := range customResource {
+						var existingCustomResource model.CustomResource
+						query := db.Session(&gorm.Session{NewDB: true})
+						if errCR := query.Where("id = ?", cr.ID).First(&existingCustomResource).Error; errCR != nil {
+							if errors.Is(errCR, gorm.ErrRecordNotFound) {
+								if errCRC := query.Create(&cr).Error; errCRC != nil {
+									blog.Errorf("create customResource failed: %v", errCRC)
+								}
+								blog.Infof("GetBcsWorkload customResourceWithDB create: %s.%s",
+									cr.ClusterUID, cr.Name)
+							} else {
+								blog.Errorf("query customResource failed: %v", errCR)
+							}
+						} else {
+							if errCRS := query.Save(&cr).Error; errCRS != nil {
+								blog.Errorf("update customResource failed: %v", errCRS)
+							} else {
+								blog.Infof("GetBcsWorkload customResourceWithDB update: %s.%s",
+									cr.ClusterUID, cr.Name)
 							}
 						}
 					}
@@ -1838,6 +1885,15 @@ func deleteBcsWorkloadDB(request *client.DeleteBcsWorkloadRequest, db *gorm.DB) 
 				blog.Errorf("delete bcs podsWordload failed: %v", err)
 			} else {
 				blog.Infof("DeleteBcsWorkload podsWordloadWithDB delete: %v", *request.IDs)
+			}
+		}
+	case CustomResource:
+		if db != nil {
+			query := db.Session(&gorm.Session{NewDB: true})
+			if err := query.Where("id in (?)", *request.IDs).Delete(&model.CustomResource{}).Error; err != nil {
+				blog.Errorf("delete bcs customResource failed: %v", err)
+			} else {
+				blog.Infof("DeleteBcsWorkload customResourceWithDB delete: %v", *request.IDs)
 			}
 		}
 	}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/cmdb/cmdb_test.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/cmdb/cmdb_test.go
@@ -719,6 +719,34 @@ func Test_cmdbClient_GetBcsWorkload(t *testing.T) {
 			want:    nil,
 			wantErr: false,
 		},
+		{
+			name:   "test customResource",
+			fields: fields{},
+			args: args{
+				request: &client.GetBcsWorkloadRequest{
+					CommonRequest: client.CommonRequest{
+						BKBizID: 41,
+						Page: client.Page{
+							Limit: 100,
+							Start: 0,
+						},
+						Filter: &client.PropertyFilter{
+							Condition: "OR",
+							Rules: []client.Rule{
+								{
+									Field:    "bk_cluster_id",
+									Operator: "in",
+									Value:    []int64{879},
+								},
+							},
+						},
+					},
+					Kind: "customResource",
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -836,6 +864,71 @@ func Test_cmdbClient_CreateBcsWorkload(t *testing.T) {
 				return
 			}
 			t.Logf("CreateBcsWorkload() got = %v", got)
+		})
+	}
+}
+
+// Test_cmdbClient_CreateBcsCustomResource tests the CreateBcsWorkload method of the cmdbClient with customResource kind.
+func Test_cmdbClient_CreateBcsCustomResource(t *testing.T) {
+	bkBizID := int64(100148)
+	kind := "customResource"
+	nsid := int64(1156)
+	name := "test-custom-resource"
+	replicas := int64(1)
+	minReadySeconds := int64(0)
+	strategyType := ""
+	crKind := "CronJob"
+	crApiVersion := "batch.tkestack.io/v1"
+
+	type fields struct {
+		config   *Options
+		userAuth string
+	}
+	type args struct {
+		request *client.CreateBcsWorkloadRequest
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *[]int64
+		wantErr bool
+	}{
+		{
+			name:   "test customResource create",
+			fields: fields{},
+			args: args{
+				request: &client.CreateBcsWorkloadRequest{
+					BKBizID: &bkBizID,
+					Kind:    &kind,
+					Data: &[]client.CreateBcsWorkloadRequestData{
+						{
+							NamespaceID:     &nsid,
+							Name:            &name,
+							Labels:          &map[string]string{"app": "test"},
+							Selector:        &bkcmdbkube.LabelSelector{},
+							Replicas:        &replicas,
+							MinReadySeconds: &minReadySeconds,
+							StrategyType:    &strategyType,
+							CRKind:          &crKind,
+							CRApiVersion:    &crApiVersion,
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := getCli()
+			got, err := c.CreateBcsWorkload(tt.args.request, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateBcsCustomResource() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			t.Logf("CreateBcsCustomResource() got = %v", got)
 		})
 	}
 }
@@ -1445,7 +1538,7 @@ func Test_deleteAllByBkBizID(t *testing.T) {
 	t.Logf("delete all pod success")
 
 	t.Logf("start delete all workload")
-	workloadTypes := []string{"deployment", "statefulSet", "daemonSet", "gameDeployment", "gameStatefulSet", "pods"}
+	workloadTypes := []string{"deployment", "statefulSet", "daemonSet", "gameDeployment", "gameStatefulSet", "pods", "customResource"}
 
 	for _, workloadType := range workloadTypes {
 		for {
@@ -1670,7 +1763,7 @@ func Test_deleteAllByBkBizIDAndBkClusterID(t *testing.T) {
 	t.Logf("delete all pod success")
 
 	t.Logf("start delete all workload")
-	workloadTypes := []string{"deployment", "statefulSet", "daemonSet", "gameDeployment", "gameStatefulSet", "pods"}
+	workloadTypes := []string{"deployment", "statefulSet", "daemonSet", "gameDeployment", "gameStatefulSet", "pods", "customResource"}
 
 	for _, workloadType := range workloadTypes {
 		for {
@@ -1985,7 +2078,7 @@ func getAllByBkBizIDNamespaces(namespaces map[int64]string, clusterUID string, c
 // Test_getAllByBkBizID tests get all bcs resources by bizid
 func Test_getAllByBkBizID(t *testing.T) { // nolint: cyclop
 	bkBizID = 110
-	workloadTypes := []string{"deployment", "statefulSet", "daemonSet", "gameDeployment", "gameStatefulSet"}
+	workloadTypes := []string{"deployment", "statefulSet", "daemonSet", "gameDeployment", "gameStatefulSet", "customResource"}
 	c := getCli()
 	t.Logf("start get all cluster")
 	clusters := make(map[int64]string, 0)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/types.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/types.go
@@ -420,6 +420,10 @@ type CreateBcsWorkloadRequestData struct {
 	MinReadySeconds       *int64                    `json:"min_ready_seconds,omitempty" bson:"min_ready_seconds"`
 	StrategyType          *string                   `json:"strategy_type,omitempty" bson:"strategy_type"`
 	RollingUpdateStrategy *map[string]interface{}   `json:"rolling_update_strategy,omitempty" bson:"rolling_update_strategy"` // nolint
+	// CRKind is the kind of custom resource, required when kind is customResource
+	CRKind *string `json:"cr_kind,omitempty" bson:"cr_kind"`
+	// CRApiVersion is the api version of custom resource, required when kind is customResource
+	CRApiVersion *string `json:"cr_api_version,omitempty" bson:"cr_api_version"`
 }
 
 // CreateBcsWorkloadResponse defines the structure of the response for creating a BCS workload.

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/common/common.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/common/common.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -117,4 +118,19 @@ func FirstLower(s string) string {
 		return ""
 	}
 	return strings.ToLower(s[:1]) + s[1:]
+}
+
+// SetCustomResourceTypesFromEnv parses synchronizer_customResourceTypes environment variable
+// and sets it to the option. The env value should be a JSON string, e.g., '{"cluster-id-1":["BkApp"]}'
+func SetCustomResourceTypesFromEnv(opt *option.BkcmdbSynchronizerOption) error {
+	envValue := os.Getenv("synchronizer_customResourceTypes")
+	if envValue == "" {
+		return nil
+	}
+	var result map[string][]string
+	if err := json.Unmarshal([]byte(envValue), &result); err != nil {
+		return fmt.Errorf("unmarshal custom resource types failed: %w", err)
+	}
+	opt.Synchronizer.CustomResourceTypes = result
+	return nil
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/common/common.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/common/common.go
@@ -134,3 +134,13 @@ func SetCustomResourceTypesFromEnv(opt *option.BkcmdbSynchronizerOption) error {
 	opt.Synchronizer.CustomResourceTypes = result
 	return nil
 }
+
+// IsKindInSlice checks if a kind exists in the whitelist
+func IsKindInSlice(kind string, whitelist []string) bool {
+	for _, s := range whitelist {
+		if s == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/common/common_test.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/common/common_test.go
@@ -1,0 +1,116 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option"
+)
+
+func TestSetCustomResourceTypesFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     map[string][]string
+		wantErr  bool
+		setup    func()
+		teardown func()
+	}{
+		{
+			name:     "empty env value",
+			envValue: "",
+			want:     nil,
+			wantErr:  false,
+			setup:    func() {},
+			teardown: func() {},
+		},
+		{
+			name:     "single cluster single type",
+			envValue: `{"cluster-id-1":["BkApp"]}`,
+			want:     map[string][]string{"cluster-id-1": {"BkApp"}},
+			wantErr:  false,
+			setup:    func() {},
+			teardown: func() {},
+		},
+		{
+			name:     "multiple clusters multiple types",
+			envValue: `{"cluster-id-1":["BkApp","CronJob"],"cluster-id-2":["BkApp"]}`,
+			want: map[string][]string{
+				"cluster-id-1": {"BkApp", "CronJob"},
+				"cluster-id-2": {"BkApp"},
+			},
+			wantErr:  false,
+			setup:    func() {},
+			teardown: func() {},
+		},
+		{
+			name:     "empty map",
+			envValue: "{}",
+			want:     map[string][]string{},
+			wantErr:  false,
+			setup:    func() {},
+			teardown: func() {},
+		},
+		{
+			name:     "invalid json",
+			envValue: `{invalid}`,
+			want:     nil,
+			wantErr:  true,
+			setup:    func() {},
+			teardown: func() {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			defer tt.teardown()
+
+			os.Setenv("synchronizer_customResourceTypes", tt.envValue)
+			defer os.Unsetenv("synchronizer_customResourceTypes")
+
+			opt := &option.BkcmdbSynchronizerOption{}
+			err := SetCustomResourceTypesFromEnv(opt)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetCustomResourceTypesFromEnv() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !compareMapStringSlices(opt.Synchronizer.CustomResourceTypes, tt.want) {
+				t.Errorf("SetCustomResourceTypesFromEnv() = %v, want %v", opt.Synchronizer.CustomResourceTypes, tt.want)
+			}
+		})
+	}
+}
+
+func compareMapStringSlices(a, b map[string][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, aVals := range a {
+		bVals, ok := b[k]
+		if !ok {
+			return false
+		}
+		if len(aVals) != len(bVals) {
+			return false
+		}
+		for i := range aVals {
+			if aVals[i] != bVals[i] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -25,6 +25,7 @@ import (
 	bkcmdbkube "configcenter/src/kube/types" // nolint
 
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi"
 	pmp "github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi/bcsproject"
 	cmp "github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi/clustermanager"
 	"github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi/storage"
@@ -36,6 +37,7 @@ import (
 	"gorm.io/gorm"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client"
 	cm "github.com/Tencent/bk-bcs/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client/clustermanager"
@@ -49,6 +51,8 @@ import (
 const (
 	// Deployment 表示Kubernetes中的部署资源类型
 	Deployment = "Deployment"
+	// StatefulSet 表示Kubernetes中的有状态副本集资源类型
+	StatefulSet = "StatefulSet"
 )
 
 var workloadKindList = []string{"GameDeployment", "GameStatefulSet", "StatefulSet", "DaemonSet", "Deployment"}
@@ -859,6 +863,171 @@ func (b *BcsBkcmdbSynchronizerHandler) handlePodsDelete(
 	return err
 }
 
+// resolveWorkloadOwner 尝试从 Workload 向上追溯获取最终的 workload 信息
+// 如果 Workload 的 Owner 是 CR 白名单中的类型，则返回 CR 的信息
+// 否则返回 Workload 本身的信息
+// workloadKind 取值: Deployment, StatefulSet
+func (b *BcsBkcmdbSynchronizerHandler) resolveWorkloadOwner(
+	clusterUID string,
+	namespaceName string,
+	workloadKind string,
+	workloadName string,
+	storageCli bcsapi.Storage,
+	crKinds []string,
+) (resolvedKind string, resolvedName string) {
+	// 初始值：关联到原始 Workload
+	resolvedKind = workloadKind
+	resolvedName = workloadName
+
+	// 如果没有配置 CR 白名单，直接返回
+	if len(crKinds) == 0 {
+		return
+	}
+
+	// 查询 Workload 的详细信息
+	var workloadList interface{}
+	var err error
+
+	switch workloadKind {
+	case "deployment":
+		workloadList, err = storageCli.QueryK8SDeployment(clusterUID, namespaceName)
+	case "statefulset":
+		workloadList, err = storageCli.QueryK8SStatefulSet(clusterUID, namespaceName)
+	default:
+		blog.Warnf("resolveWorkloadOwner: unsupported workload kind %s", workloadKind)
+		return
+	}
+
+	if err != nil {
+		blog.Warnf("query %s %s from storage failed: %s, use %s as fallback",
+			workloadKind, workloadName, err.Error(), workloadKind)
+		return
+	}
+
+	if workloadList == nil {
+		blog.Warnf("%s %s not found in storage, use %s as fallback",
+			workloadKind, workloadName, workloadKind)
+		return
+	}
+
+	// 查找匹配的 Workload 并获取其 Owner
+	var ownerRef metav1.OwnerReference
+	found := false
+
+	switch w := workloadList.(type) {
+	case []*storage.Deployment:
+		for _, deploy := range w {
+			if deploy.Data.Name == workloadName {
+				if len(deploy.Data.OwnerReferences) > 0 {
+					ownerRef = deploy.Data.OwnerReferences[0]
+					found = true
+				}
+				break
+			}
+		}
+	case []*storage.StatefulSet:
+		for _, ss := range w {
+			if ss.Data.Name == workloadName {
+				if len(ss.Data.OwnerReferences) > 0 {
+					ownerRef = ss.Data.OwnerReferences[0]
+					found = true
+				}
+				break
+			}
+		}
+	}
+
+	if !found {
+		blog.Infof("%s %s has no owner, use %s", workloadKind, workloadName, workloadKind)
+		return
+	}
+
+	// 检查 Owner 是否在 CR 白名单中
+	if common.IsKindInSlice(ownerRef.Kind, crKinds) {
+		resolvedKind = "customResource"
+		resolvedName = ownerRef.Name
+		blog.Infof("found CR owner: %s/%s for Pod via %s %s",
+			ownerRef.Kind, ownerRef.Name, workloadKind, workloadName)
+	} else {
+		blog.Infof("%s %s owner %s not in CR whitelist, use %s",
+			workloadKind, workloadName, ownerRef.Kind, workloadKind)
+	}
+
+	return
+}
+
+// isWorkloadOwnedByCR 检查 workload 的 owner 是否在 CR 白名单中
+// 如果是，返回 (true, crKind)；否则返回 (false, "")
+func (b *BcsBkcmdbSynchronizerHandler) isWorkloadOwnedByCR(
+	clusterUID, namespaceName, workloadKind, workloadName string,
+	storageCli bcsapi.Storage, crKinds []string) (bool, string) {
+
+	if len(crKinds) == 0 {
+		return false, ""
+	}
+
+	// 查询 Workload 详细信息
+	var workloadList interface{}
+	var err error
+
+	switch workloadKind {
+	case "deployment":
+		workloadList, err = storageCli.QueryK8SDeployment(clusterUID, namespaceName)
+	case "statefulset":
+		workloadList, err = storageCli.QueryK8SStatefulSet(clusterUID, namespaceName)
+	default:
+		return false, ""
+	}
+
+	if err != nil {
+		blog.Warnf("query %s %s from storage failed: %s, skip CR owner check",
+			workloadKind, workloadName, err.Error())
+		return false, ""
+	}
+
+	if workloadList == nil {
+		blog.Warnf("%s %s not found in storage, skip CR owner check",
+			workloadKind, workloadName)
+		return false, ""
+	}
+
+	// 查找匹配的 Workload 并获取其 Owner
+	var ownerRef metav1.OwnerReference
+	found := false
+
+	switch w := workloadList.(type) {
+	case []*storage.Deployment:
+		for _, deploy := range w {
+			if deploy.Data.Name == workloadName && len(deploy.Data.OwnerReferences) > 0 {
+				ownerRef = deploy.Data.OwnerReferences[0]
+				found = true
+				break
+			}
+		}
+	case []*storage.StatefulSet:
+		for _, ss := range w {
+			if ss.Data.Name == workloadName && len(ss.Data.OwnerReferences) > 0 {
+				ownerRef = ss.Data.OwnerReferences[0]
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		return false, ""
+	}
+
+	// 检查 owner 是否在 CR 白名单中
+	if common.IsKindInSlice(ownerRef.Kind, crKinds) {
+		blog.Infof("workload %s %s/%s is owned by CR %s, skip sync",
+			workloadKind, namespaceName, workloadName, ownerRef.Kind)
+		return true, ownerRef.Kind
+	}
+
+	return false, ""
+}
+
 // handle pod create
 // nolint funlen
 func (b *BcsBkcmdbSynchronizerHandler) handlePodCreate(pod *corev1.Pod, bkCluster *bkcmdbkube.Cluster) error {
@@ -961,9 +1130,16 @@ func (b *BcsBkcmdbSynchronizerHandler) handlePodCreate(pod *corev1.Pod, bkCluste
 			}
 			rsOwnerRef := rs.Data.OwnerReferences[0]
 			switch rsOwnerRef.Kind {
-			case Deployment:
-				workloadKind = "deployment"
-				workloadName = rsOwnerRef.Name
+			case Deployment, StatefulSet:
+				// 获取该集群的 CR 白名单
+				clusterID := bkCluster.Uid
+				crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+
+				// 尝试从 Workload 向上追溯获取最终的 workload 信息
+				workloadKind, workloadName = b.resolveWorkloadOwner(
+					bkCluster.Uid, bkNamespace.Name, rsOwnerRef.Kind, rsOwnerRef.Name, storageCli, crKinds)
+
+				// 通过 workloadKind/workloadName 查询 CMDB
 				bkWorkloads, err := b.Syncer.GetBkWorkloads(bkCluster.BizID, workloadKind, &client.PropertyFilter{
 					Condition: "AND",
 					Rules: []client.Rule{
@@ -1352,9 +1528,16 @@ func (b *BcsBkcmdbSynchronizerHandler) handlePodsCreate(podsCreate map[string]*c
 				}
 				rsOwnerRef := rs.Data.OwnerReferences[0]
 				switch rsOwnerRef.Kind {
-				case Deployment:
-					workloadKind = "deployment"
-					workloadName = rsOwnerRef.Name
+				case Deployment, StatefulSet:
+					// 获取该集群的 CR 白名单
+					clusterID := bkCluster.Uid
+					crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+
+					// 尝试从 Workload 向上追溯获取最终的 workload 信息
+					workloadKind, workloadName = b.resolveWorkloadOwner(
+						bkCluster.Uid, bkNamespace.Name, rsOwnerRef.Kind, rsOwnerRef.Name, storageCli, crKinds)
+
+					// 通过 workloadKind/workloadName 查询 CMDB
 					bkWorkloads, errW := b.Syncer.GetBkWorkloads(bkCluster.BizID, workloadKind, &client.PropertyFilter{
 						Condition: "AND",
 						Rules: []client.Rule{
@@ -1691,6 +1874,24 @@ func (b *BcsBkcmdbSynchronizerHandler) handleDeployment(
 // handleDeploymentUpdate 处理部署更新的函数
 func (b *BcsBkcmdbSynchronizerHandler) handleDeploymentUpdate(
 	deployment *appv1.Deployment, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// 检查该 Deployment 是否被 CR 拥有，如果是则跳过
+	clusterID := bkCluster.Uid
+	crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+	if len(crKinds) > 0 {
+		storageCli, err := b.Syncer.GetBcsStorageClient()
+		if err != nil {
+			blog.Errorf("get bcs storage client failed, err: %s", err.Error())
+		} else {
+			ownedByCR, crKind := b.isWorkloadOwnedByCR(
+				bkCluster.Uid, deployment.Namespace, "deployment", deployment.Name, storageCli, crKinds)
+			if ownedByCR {
+				blog.Infof("deployment %s/%s is owned by CR %s, skip update",
+					deployment.Namespace, deployment.Name, crKind)
+				return nil
+			}
+		}
+	}
+
 	// 获取与当前部署相关的bk工作负载
 	bkDeployments, err := b.Syncer.GetBkWorkloads(bkCluster.BizID, "deployment", &client.PropertyFilter{
 		Condition: "AND",
@@ -1836,6 +2037,24 @@ func (b *BcsBkcmdbSynchronizerHandler) handleDeploymentDelete(
 
 func (b *BcsBkcmdbSynchronizerHandler) handleDeploymentCreate(
 	deployment *appv1.Deployment, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// 检查该 Deployment 是否被 CR 拥有，如果是则跳过
+	clusterID := bkCluster.Uid
+	crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+	if len(crKinds) > 0 {
+		storageCli, err := b.Syncer.GetBcsStorageClient()
+		if err != nil {
+			blog.Errorf("get bcs storage client failed, err: %s", err.Error())
+		} else {
+			ownedByCR, crKind := b.isWorkloadOwnedByCR(
+				bkCluster.Uid, deployment.Namespace, "deployment", deployment.Name, storageCli, crKinds)
+			if ownedByCR {
+				blog.Infof("deployment %s/%s is owned by CR %s, skip create",
+					deployment.Namespace, deployment.Name, crKind)
+				return nil
+			}
+		}
+	}
+
 	bkNamespaces, err := b.Syncer.GetBkNamespaces(bkCluster.BizID, &client.PropertyFilter{
 		Condition: "AND",
 		Rules: []client.Rule{
@@ -1908,6 +2127,24 @@ func (b *BcsBkcmdbSynchronizerHandler) handleStatefulSet(
 
 func (b *BcsBkcmdbSynchronizerHandler) handleStatefulSetUpdate(
 	statefulSet *appv1.StatefulSet, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// 检查该 StatefulSet 是否被 CR 拥有，如果是则跳过
+	clusterID := bkCluster.Uid
+	crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+	if len(crKinds) > 0 {
+		storageCli, err := b.Syncer.GetBcsStorageClient()
+		if err != nil {
+			blog.Errorf("get bcs storage client failed, err: %s", err.Error())
+		} else {
+			ownedByCR, crKind := b.isWorkloadOwnedByCR(
+				bkCluster.Uid, statefulSet.Namespace, "statefulset", statefulSet.Name, storageCli, crKinds)
+			if ownedByCR {
+				blog.Infof("statefulset %s/%s is owned by CR %s, skip update",
+					statefulSet.Namespace, statefulSet.Name, crKind)
+				return nil
+			}
+		}
+	}
+
 	bkStatefulSets, err := b.Syncer.GetBkWorkloads(bkCluster.BizID, "statefulSet", &client.PropertyFilter{
 		Condition: "AND",
 		Rules: []client.Rule{
@@ -2028,6 +2265,24 @@ func (b *BcsBkcmdbSynchronizerHandler) handleStatefulSetDelete(
 
 func (b *BcsBkcmdbSynchronizerHandler) handleStatefulSetCreate(
 	statefulSet *appv1.StatefulSet, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// 检查该 StatefulSet 是否被 CR 拥有，如果是则跳过
+	clusterID := bkCluster.Uid
+	crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+	if len(crKinds) > 0 {
+		storageCli, err := b.Syncer.GetBcsStorageClient()
+		if err != nil {
+			blog.Errorf("get bcs storage client failed, err: %s", err.Error())
+		} else {
+			ownedByCR, crKind := b.isWorkloadOwnedByCR(
+				bkCluster.Uid, statefulSet.Namespace, "statefulset", statefulSet.Name, storageCli, crKinds)
+			if ownedByCR {
+				blog.Infof("statefulset %s/%s is owned by CR %s, skip create",
+					statefulSet.Namespace, statefulSet.Name, crKind)
+				return nil
+			}
+		}
+	}
+
 	bkNamespaces, err := b.Syncer.GetBkNamespaces(bkCluster.BizID, &client.PropertyFilter{
 		Condition: "AND",
 		Rules: []client.Rule{

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -3862,7 +3862,15 @@ func (b *BcsBkcmdbSynchronizerHandler) handleCustomResourceDelete(
 	if id, ok := bkCRMap["id"].(float64); ok {
 		blog.Infof("customResourceToDelete: %s/%s, crKind=%s, id=%d", msgHeader.Namespace,
 			msgHeader.ResourceName, crKind, int64(id))
-		return b.Syncer.DeleteBkWorkloads(bkCluster, "customResource", &[]int64{int64(id)}, db)
+		err = retry.Do(
+			func() error {
+				return b.Syncer.DeleteBkWorkloads(bkCluster, "customResource", &[]int64{int64(id)}, db)
+			},
+			retry.Delay(time.Second*1),
+			retry.Attempts(2),
+			retry.DelayType(retry.FixedDelay),
+		)
+		return err
 	}
 
 	return fmt.Errorf("customResource %s/%s id not found", msgHeader.Namespace, msgHeader.ResourceName)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -875,8 +875,7 @@ func (b *BcsBkcmdbSynchronizerHandler) resolveWorkloadOwner(
 	storageCli bcsapi.Storage,
 	crKinds []string,
 ) (resolvedKind string, resolvedName string) {
-	// 初始值：关联到原始 Workload
-	resolvedKind = workloadKind
+	resolvedKind = common.FirstLower(workloadKind)
 	resolvedName = workloadName
 
 	// 如果没有配置 CR 白名单，直接返回
@@ -889,9 +888,9 @@ func (b *BcsBkcmdbSynchronizerHandler) resolveWorkloadOwner(
 	var err error
 
 	switch workloadKind {
-	case "deployment":
+	case "Deployment":
 		workloadList, err = storageCli.QueryK8SDeployment(clusterUID, namespaceName)
-	case "statefulset":
+	case "StatefulSet":
 		workloadList, err = storageCli.QueryK8SStatefulSet(clusterUID, namespaceName)
 	default:
 		blog.Warnf("resolveWorkloadOwner: unsupported workload kind %s", workloadKind)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -3862,6 +3862,39 @@ func (b *BcsBkcmdbSynchronizerHandler) handleCustomResourceDelete(
 	if id, ok := bkCRMap["id"].(float64); ok {
 		blog.Infof("customResourceToDelete: %s/%s, crKind=%s, id=%d", msgHeader.Namespace,
 			msgHeader.ResourceName, crKind, int64(id))
+
+		// 1. Get pods associated with this custom resource, delete them first
+		// This is necessary because if a CR still has associated Pods in CMDB, the delete-workload-api will fail.
+		// Since MQ events are processed serially per cluster, we might handle the CR-Delete before the Pod-Delete.
+		bkPods, errGetPods := b.Syncer.GetBkPods(bkCluster.BizID, &client.PropertyFilter{
+			Condition: "AND",
+			Rules: []client.Rule{
+				{
+					Field:    "ref.kind",
+					Operator: "in",
+					Value:    []string{"customResource"},
+				},
+				{
+					Field:    "ref.id",
+					Operator: "in",
+					Value:    []int64{int64(id)},
+				},
+			},
+		}, true, db)
+		if errGetPods == nil && len(*bkPods) > 0 {
+			podIDs := make([]int64, 0)
+			for _, pod := range *bkPods {
+				podIDs = append(podIDs, pod.ID)
+			}
+			blog.Infof("customResource %s/%s has %d pods, delete them first",
+				msgHeader.Namespace, msgHeader.ResourceName, len(podIDs))
+			if errDelPods := b.Syncer.DeleteBkPods(bkCluster, &podIDs, db); errDelPods != nil {
+				// We log the error but continue to try deleting the workload anyway in the retry block
+				blog.Errorf("delete pods for customResource %s/%s failed: %v",
+					msgHeader.Namespace, msgHeader.ResourceName, errDelPods)
+			}
+		}
+
 		err = retry.Do(
 			func() error {
 				return b.Syncer.DeleteBkWorkloads(bkCluster, "customResource", &[]int64{int64(id)}, db)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -3866,7 +3866,7 @@ func (b *BcsBkcmdbSynchronizerHandler) handleCustomResourceDelete(
 			func() error {
 				return b.Syncer.DeleteBkWorkloads(bkCluster, "customResource", &[]int64{int64(id)}, db)
 			},
-			retry.Delay(time.Second*1),
+			retry.Delay(time.Second*2),
 			retry.Attempts(2),
 			retry.DelayType(retry.FixedDelay),
 		)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	bkcmdbkube "configcenter/src/kube/types" // nolint
+
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	pmp "github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi/bcsproject"
 	cmp "github.com/Tencent/bk-bcs/bcs-common/pkg/bcsapi/clustermanager"
@@ -225,6 +226,10 @@ func (b *BcsBkcmdbSynchronizerHandler) HandleMsg(
 					}
 					errH = b.handleNodes(&nodeMsg, bkCluster, db)
 					// errH = b.handleEvent(msg, bkCluster)
+				default:
+					// 未匹配的 resourceType 当作 CustomResource 处理
+					// handleCustomResource 内部会校验该 crKind 是否在白名单中
+					errH = b.handleCustomResource(msg, bkCluster, db)
 				}
 
 				if errH != nil {
@@ -3285,4 +3290,347 @@ func (b *BcsBkcmdbSynchronizerHandler) PublishMsg(msg amqp.Delivery, rep int32) 
 
 	// Return the error if there is one, or nil if the message was published successfully.
 	return err
+}
+
+// CustomResourceData represents the message body for custom resource events.
+// The body is the raw K8s object JSON from bcs-storage.
+type CustomResourceData map[string]interface{}
+
+// handleCustomResource handles custom resource messages from RabbitMQ.
+func (b *BcsBkcmdbSynchronizerHandler) handleCustomResource(
+	msg amqp.Delivery, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// Get message header
+	msgHeader, err := getMsgHeader(&msg.Headers)
+	if err != nil {
+		blog.Errorf("handleCustomResource unable to get headers, err: %s", err.Error())
+		return fmt.Errorf("handleCustomResource unable to get headers, err: %s", err.Error())
+	}
+
+	// Kind from Header.resourceType (not from body)
+	crKind := msgHeader.ResourceType
+	if crKind == "" {
+		blog.Errorf("handleCustomResource: crKind is empty")
+		return fmt.Errorf("handleCustomResource: crKind is empty")
+	}
+
+	// Whitelist check - get cluster ID from message header
+	clusterID := msgHeader.ClusterId
+	crKinds, ok := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+	if !ok || len(crKinds) == 0 {
+		blog.Infof("cluster %s not configured for custom resource sync, skip", clusterID)
+		return nil
+	}
+
+	// Check if this crKind is in the whitelist
+	isWhitelisted := false
+	for _, k := range crKinds {
+		if k == crKind {
+			isWhitelisted = true
+			break
+		}
+	}
+	if !isWhitelisted {
+		blog.Infof("cluster %s crKind %s not in whitelist, skip", clusterID, crKind)
+		return nil
+	}
+
+	// Parse body as raw K8s object map
+	var crData CustomResourceData
+	err = json.Unmarshal(msg.Body, &crData)
+	if err != nil {
+		blog.Errorf("handleCustomResource: unable to unmarshal, err: %s", err.Error())
+		return fmt.Errorf("handleCustomResource: unable to unmarshal, err: %s", err.Error())
+	}
+
+	blog.Infof("handleCustomResource: cluster=%s, crKind=%s, event=%s, namespace=%s, resourceName=%s",
+		clusterID, crKind, msgHeader.Event, msgHeader.Namespace, msgHeader.ResourceName)
+
+	// Handle based on event type
+	switch msgHeader.Event {
+	case "update":
+		return b.handleCustomResourceUpdate(crData, crKind, msgHeader, bkCluster, db)
+	case "delete":
+		return b.handleCustomResourceDelete(crData, crKind, msgHeader, bkCluster, db)
+	case "create":
+		return b.handleCustomResourceCreate(crData, crKind, msgHeader, bkCluster, db)
+	default:
+		blog.Errorf("handleCustomResource: Unknown event: %s", msgHeader.Event)
+		return fmt.Errorf("handleCustomResource: Unknown event: %s", msgHeader.Event)
+	}
+}
+
+// handleCustomResourceCreate handles custom resource creation.
+func (b *BcsBkcmdbSynchronizerHandler) handleCustomResourceCreate(
+	crData CustomResourceData, crKind string, msgHeader *MsgHeader, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// Get bk namespace
+	bkNamespaces, err := b.Syncer.GetBkNamespaces(bkCluster.BizID, &client.PropertyFilter{
+		Condition: "AND",
+		Rules: []client.Rule{
+			{
+				Field:    "name",
+				Operator: "in",
+				Value:    []string{msgHeader.Namespace},
+			},
+			{
+				Field:    "cluster_uid",
+				Operator: "in",
+				Value:    []string{bkCluster.Uid},
+			},
+		},
+	}, true, db)
+	if err != nil {
+		return err
+	}
+	if len(*bkNamespaces) != 1 {
+		return fmt.Errorf("len(bkNamespaces) = %d", len(*bkNamespaces))
+	}
+	bkNamespace := (*bkNamespaces)[0]
+
+	// Check if already exists - try update first
+	bkCRs, err := b.Syncer.GetBkWorkloads(bkCluster.BizID, "customResource", &client.PropertyFilter{
+		Condition: "AND",
+		Rules: []client.Rule{
+			{
+				Field:    "name",
+				Operator: "in",
+				Value:    []string{msgHeader.ResourceName},
+			},
+			{
+				Field:    "cluster_uid",
+				Operator: "in",
+				Value:    []string{bkCluster.Uid},
+			},
+			{
+				Field:    "namespace",
+				Operator: "in",
+				Value:    []string{msgHeader.Namespace},
+			},
+			{
+				Field:    "cr_kind",
+				Operator: "in",
+				Value:    []string{crKind},
+			},
+		},
+	}, true, db)
+	if err != nil {
+		return err
+	}
+
+	// If exists, update instead
+	if len(*bkCRs) > 0 {
+		return b.handleCustomResourceUpdate(crData, crKind, msgHeader, bkCluster, db)
+	}
+
+	// Extract fields from crData
+	labels := extractLabels(crData)
+	replicas := extractReplicas(crData)
+	apiVersion := extractApiVersion(crData)
+
+	// Create new
+	kind := "customResource"
+	crToAdd := make(map[int64][]client.CreateBcsWorkloadRequestData, 0)
+	toAddData := &client.CreateBcsWorkloadRequestData{
+		NamespaceID:  &bkNamespace.ID,
+		Name:         &msgHeader.ResourceName,
+		Labels:       &labels,
+		Replicas:     &replicas,
+		CRKind:       &crKind,
+		CRApiVersion: &apiVersion,
+	}
+	crToAdd[bkNamespace.BizID] = []client.CreateBcsWorkloadRequestData{*toAddData}
+	blog.Infof("customResourceToAdd: %s/%s, crKind=%s", msgHeader.Namespace, msgHeader.ResourceName, crKind)
+
+	b.Syncer.CreateBkWorkloads(bkCluster, kind, crToAdd, db)
+	return nil
+}
+
+// handleCustomResourceUpdate handles custom resource update.
+func (b *BcsBkcmdbSynchronizerHandler) handleCustomResourceUpdate(
+	crData CustomResourceData, crKind string, msgHeader *MsgHeader, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// Get existing bk workload
+	bkCRs, err := b.Syncer.GetBkWorkloads(bkCluster.BizID, "customResource", &client.PropertyFilter{
+		Condition: "AND",
+		Rules: []client.Rule{
+			{
+				Field:    "name",
+				Operator: "in",
+				Value:    []string{msgHeader.ResourceName},
+			},
+			{
+				Field:    "cluster_uid",
+				Operator: "in",
+				Value:    []string{bkCluster.Uid},
+			},
+			{
+				Field:    "namespace",
+				Operator: "in",
+				Value:    []string{msgHeader.Namespace},
+			},
+			{
+				Field:    "cr_kind",
+				Operator: "in",
+				Value:    []string{crKind},
+			},
+		},
+	}, true, db)
+	if err != nil {
+		return err
+	}
+
+	// If not exists, create instead
+	if len(*bkCRs) == 0 {
+		return b.handleCustomResourceCreate(crData, crKind, msgHeader, bkCluster, db)
+	}
+	if len(*bkCRs) > 1 {
+		return fmt.Errorf("len(bkCRs) = %d", len(*bkCRs))
+	}
+
+	// Get the existing CR
+	bkCR := (*bkCRs)[0]
+	bkCRMap, ok := bkCR.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("bkCR is not map[string]interface{}")
+	}
+
+	// Extract fields from crData
+	labels := extractLabels(crData)
+	replicas := extractReplicas(crData)
+
+	// Check if update is needed
+	needUpdate := false
+	updateData := &client.UpdateBcsWorkloadRequestData{}
+
+	// Compare labels
+	if labels != nil {
+		if bkLabels, ok := bkCRMap["labels"].(map[string]interface{}); ok {
+			for k, v := range labels {
+				if bkV, ok := bkLabels[k].(string); !ok || bkV != v {
+					needUpdate = true
+					break
+				}
+			}
+		} else {
+			needUpdate = true
+		}
+	}
+
+	// Compare replicas
+	if !needUpdate && replicas > 0 {
+		if bkReplicas, ok := bkCRMap["replicas"].(float64); ok {
+			if int64(bkReplicas) != replicas {
+				needUpdate = true
+				updateData.Replicas = &replicas
+			}
+		} else {
+			needUpdate = true
+			updateData.Replicas = &replicas
+		}
+	}
+
+	if !needUpdate {
+		blog.Infof("customResource %s/%s no update needed", msgHeader.Namespace, msgHeader.ResourceName)
+		return nil
+	}
+
+	// Get ID for update
+	if id, ok := bkCRMap["id"].(float64); ok {
+		blog.Infof("customResourceToUpdate: %s/%s, crKind=%s, id=%d", msgHeader.Namespace,
+			msgHeader.ResourceName, crKind, int64(id))
+		b.Syncer.UpdateBkWorkloads(bkCluster, "customResource",
+			&map[int64]*client.UpdateBcsWorkloadRequestData{int64(id): updateData}, db)
+		return nil
+	}
+
+	return fmt.Errorf("customResource %s/%s id not found", msgHeader.Namespace, msgHeader.ResourceName)
+}
+
+// handleCustomResourceDelete handles custom resource deletion.
+func (b *BcsBkcmdbSynchronizerHandler) handleCustomResourceDelete(
+	crData CustomResourceData, crKind string, msgHeader *MsgHeader, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// Get existing bk workload
+	bkCRs, err := b.Syncer.GetBkWorkloads(bkCluster.BizID, "customResource", &client.PropertyFilter{
+		Condition: "AND",
+		Rules: []client.Rule{
+			{
+				Field:    "name",
+				Operator: "in",
+				Value:    []string{msgHeader.ResourceName},
+			},
+			{
+				Field:    "cluster_uid",
+				Operator: "in",
+				Value:    []string{bkCluster.Uid},
+			},
+			{
+				Field:    "namespace",
+				Operator: "in",
+				Value:    []string{msgHeader.Namespace},
+			},
+			{
+				Field:    "cr_kind",
+				Operator: "in",
+				Value:    []string{crKind},
+			},
+		},
+	}, true, db)
+	if err != nil {
+		return err
+	}
+
+	if len(*bkCRs) == 0 {
+		blog.Infof("customResource %s/%s not found in CMDB, skip delete", msgHeader.Namespace, msgHeader.ResourceName)
+		return nil
+	}
+	if len(*bkCRs) > 1 {
+		return fmt.Errorf("len(bkCRs) = %d", len(*bkCRs))
+	}
+
+	// Get the existing CR
+	bkCR := (*bkCRs)[0]
+	bkCRMap, ok := bkCR.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("bkCR is not map[string]interface{}")
+	}
+
+	// Get ID for delete
+	if id, ok := bkCRMap["id"].(float64); ok {
+		blog.Infof("customResourceToDelete: %s/%s, crKind=%s, id=%d", msgHeader.Namespace,
+			msgHeader.ResourceName, crKind, int64(id))
+		return b.Syncer.DeleteBkWorkloads(bkCluster, "customResource", &[]int64{int64(id)}, db)
+	}
+
+	return fmt.Errorf("customResource %s/%s id not found", msgHeader.Namespace, msgHeader.ResourceName)
+}
+
+// extractLabels extracts labels from the custom resource data.
+func extractLabels(crData CustomResourceData) map[string]string {
+	labels := make(map[string]string)
+	if metadata, ok := crData["metadata"].(map[string]interface{}); ok {
+		if l, ok := metadata["labels"].(map[string]interface{}); ok {
+			for k, v := range l {
+				if vs, ok := v.(string); ok {
+					labels[k] = vs
+				}
+			}
+		}
+	}
+	return labels
+}
+
+// extractReplicas extracts replicas from the custom resource data.
+func extractReplicas(crData CustomResourceData) int64 {
+	if spec, ok := crData["spec"].(map[string]interface{}); ok {
+		if r, ok := spec["replicas"].(float64); ok {
+			return int64(r)
+		}
+	}
+	return 0
+}
+
+// extractApiVersion extracts apiVersion from the custom resource data.
+func extractApiVersion(crData CustomResourceData) string {
+	if apiVersion, ok := crData["apiVersion"].(string); ok {
+		return apiVersion
+	}
+	return ""
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -1111,7 +1111,7 @@ func (b *BcsBkcmdbSynchronizerHandler) handlePodCreate(pod *corev1.Pod, bkCluste
 			}
 			rsOwnerRef := rs.Data.OwnerReferences[0]
 			switch rsOwnerRef.Kind {
-			case Deployment, StatefulSet:
+			case Deployment:
 				// 获取该集群的 CR 白名单
 				clusterID := bkCluster.Uid
 				crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
@@ -1177,6 +1177,21 @@ func (b *BcsBkcmdbSynchronizerHandler) handlePodCreate(pod *corev1.Pod, bkCluste
 		} else if exist, _ := common.InArray(ownerRef.Kind, workloadKindList); exist {
 			workloadKind = common.FirstLower(ownerRef.Kind)
 			workloadName = ownerRef.Name
+
+			// 获取该集群的 CR 白名单
+			clusterID := bkCluster.Uid
+			crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+
+			// 如果是 StatefulSet/DaemonSet/GameDeployment/GameStatefulSet，尝试向上追溯获取最终的 CR 信息
+			if common.IsKindInSlice(ownerRef.Kind, []string{"StatefulSet", "DaemonSet", "GameDeployment", "GameStatefulSet"}) {
+				storageCli, errSts := b.Syncer.GetBcsStorageClient()
+				if errSts != nil {
+					return errSts
+				}
+				workloadKind, workloadName = b.resolveWorkloadOwner(
+					bkCluster.Uid, bkNamespace.Name, ownerRef.Kind, ownerRef.Name, storageCli, crKinds)
+			}
+
 			bkWorkloads, err := b.Syncer.GetBkWorkloads(bkCluster.BizID, workloadKind, &client.PropertyFilter{
 				Condition: "AND",
 				Rules: []client.Rule{
@@ -1509,7 +1524,7 @@ func (b *BcsBkcmdbSynchronizerHandler) handlePodsCreate(podsCreate map[string]*c
 				}
 				rsOwnerRef := rs.Data.OwnerReferences[0]
 				switch rsOwnerRef.Kind {
-				case Deployment, StatefulSet:
+				case Deployment:
 					// 获取该集群的 CR 白名单
 					clusterID := bkCluster.Uid
 					crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
@@ -1578,6 +1593,21 @@ func (b *BcsBkcmdbSynchronizerHandler) handlePodsCreate(podsCreate map[string]*c
 			} else if exist, _ := common.InArray(ownerRef.Kind, workloadKindList); exist {
 				workloadKind = common.FirstLower(ownerRef.Kind)
 				workloadName = ownerRef.Name
+
+				// 获取该集群的 CR 白名单
+				clusterID := bkCluster.Uid
+				crKinds := b.Syncer.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+
+				// 如果是 StatefulSet/DaemonSet/GameDeployment/GameStatefulSet，尝试向上追溯获取最终的 CR 信息
+				if common.IsKindInSlice(ownerRef.Kind, []string{"StatefulSet", "DaemonSet", "GameDeployment", "GameStatefulSet"}) {
+					storageCli, errSts := b.Syncer.GetBcsStorageClient()
+					if errSts != nil {
+						continue
+					}
+					workloadKind, workloadName = b.resolveWorkloadOwner(
+						bkCluster.Uid, bkNamespace.Name, ownerRef.Kind, ownerRef.Name, storageCli, crKinds)
+				}
+
 				bkWorkloads, errW := b.Syncer.GetBkWorkloads(bkCluster.BizID, workloadKind, &client.PropertyFilter{
 					Condition: "AND",
 					Rules: []client.Rule{

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -3863,38 +3863,7 @@ func (b *BcsBkcmdbSynchronizerHandler) handleCustomResourceDelete(
 		blog.Infof("customResourceToDelete: %s/%s, crKind=%s, id=%d", msgHeader.Namespace,
 			msgHeader.ResourceName, crKind, int64(id))
 
-		// 1. Get pods associated with this custom resource, delete them first
-		// This is necessary because if a CR still has associated Pods in CMDB, the delete-workload-api will fail.
-		// Since MQ events are processed serially per cluster, we might handle the CR-Delete before the Pod-Delete.
-		bkPods, errGetPods := b.Syncer.GetBkPods(bkCluster.BizID, &client.PropertyFilter{
-			Condition: "AND",
-			Rules: []client.Rule{
-				{
-					Field:    "ref.kind",
-					Operator: "in",
-					Value:    []string{"customResource"},
-				},
-				{
-					Field:    "ref.id",
-					Operator: "in",
-					Value:    []int64{int64(id)},
-				},
-			},
-		}, true, db)
-		if errGetPods == nil && len(*bkPods) > 0 {
-			podIDs := make([]int64, 0)
-			for _, pod := range *bkPods {
-				podIDs = append(podIDs, pod.ID)
-			}
-			blog.Infof("customResource %s/%s has %d pods, delete them first",
-				msgHeader.Namespace, msgHeader.ResourceName, len(podIDs))
-			if errDelPods := b.Syncer.DeleteBkPods(bkCluster, &podIDs, db); errDelPods != nil {
-				// We log the error but continue to try deleting the workload anyway in the retry block
-				blog.Errorf("delete pods for customResource %s/%s failed: %v",
-					msgHeader.Namespace, msgHeader.ResourceName, errDelPods)
-			}
-		}
-
+		// DeleteBkWorkloads will delete associated pods first before deleting the workload
 		err = retry.Do(
 			func() error {
 				return b.Syncer.DeleteBkWorkloads(bkCluster, "customResource", &[]int64{int64(id)}, db)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/handler/handler.go
@@ -884,56 +884,45 @@ func (b *BcsBkcmdbSynchronizerHandler) resolveWorkloadOwner(
 	}
 
 	// 查询 Workload 的详细信息
-	var workloadList interface{}
-	var err error
+	var ownerRef metav1.OwnerReference
+	var found bool
 
 	switch workloadKind {
 	case "Deployment":
-		workloadList, err = storageCli.QueryK8SDeployment(clusterUID, namespaceName)
+		workload, err := storageCli.GetK8SDeployment(clusterUID, namespaceName, workloadName)
+		if err != nil {
+			blog.Warnf("query deployment %s/%s from storage failed: %s, use %s as fallback",
+				namespaceName, workloadName, err.Error(), workloadKind)
+			return
+		}
+		if workload == nil {
+			blog.Warnf("deployment %s/%s not found in storage, use %s as fallback",
+				namespaceName, workloadName, workloadKind)
+			return
+		}
+		if len(workload.Data.OwnerReferences) > 0 {
+			ownerRef = workload.Data.OwnerReferences[0]
+			found = true
+		}
 	case "StatefulSet":
-		workloadList, err = storageCli.QueryK8SStatefulSet(clusterUID, namespaceName)
+		workload, err := storageCli.GetK8SStatefulSet(clusterUID, namespaceName, workloadName)
+		if err != nil {
+			blog.Warnf("query statefulset %s/%s from storage failed: %s, use %s as fallback",
+				namespaceName, workloadName, err.Error(), workloadKind)
+			return
+		}
+		if workload == nil {
+			blog.Warnf("statefulset %s/%s not found in storage, use %s as fallback",
+				namespaceName, workloadName, workloadKind)
+			return
+		}
+		if len(workload.Data.OwnerReferences) > 0 {
+			ownerRef = workload.Data.OwnerReferences[0]
+			found = true
+		}
 	default:
 		blog.Warnf("resolveWorkloadOwner: unsupported workload kind %s", workloadKind)
 		return
-	}
-
-	if err != nil {
-		blog.Warnf("query %s %s from storage failed: %s, use %s as fallback",
-			workloadKind, workloadName, err.Error(), workloadKind)
-		return
-	}
-
-	if workloadList == nil {
-		blog.Warnf("%s %s not found in storage, use %s as fallback",
-			workloadKind, workloadName, workloadKind)
-		return
-	}
-
-	// 查找匹配的 Workload 并获取其 Owner
-	var ownerRef metav1.OwnerReference
-	found := false
-
-	switch w := workloadList.(type) {
-	case []*storage.Deployment:
-		for _, deploy := range w {
-			if deploy.Data.Name == workloadName {
-				if len(deploy.Data.OwnerReferences) > 0 {
-					ownerRef = deploy.Data.OwnerReferences[0]
-					found = true
-				}
-				break
-			}
-		}
-	case []*storage.StatefulSet:
-		for _, ss := range w {
-			if ss.Data.Name == workloadName {
-				if len(ss.Data.OwnerReferences) > 0 {
-					ownerRef = ss.Data.OwnerReferences[0]
-					found = true
-				}
-				break
-			}
-		}
 	}
 
 	if !found {
@@ -966,51 +955,44 @@ func (b *BcsBkcmdbSynchronizerHandler) isWorkloadOwnedByCR(
 	}
 
 	// 查询 Workload 详细信息
-	var workloadList interface{}
-	var err error
+	var ownerRef metav1.OwnerReference
+	var found bool
 
 	switch workloadKind {
 	case "deployment":
-		workloadList, err = storageCli.QueryK8SDeployment(clusterUID, namespaceName)
+		workload, err := storageCli.GetK8SDeployment(clusterUID, namespaceName, workloadName)
+		if err != nil {
+			blog.Warnf("query deployment %s/%s from storage failed: %s, skip CR owner check",
+				namespaceName, workloadName, err.Error())
+			return false, ""
+		}
+		if workload == nil {
+			blog.Warnf("deployment %s/%s not found in storage, skip CR owner check",
+				namespaceName, workloadName)
+			return false, ""
+		}
+		if len(workload.Data.OwnerReferences) > 0 {
+			ownerRef = workload.Data.OwnerReferences[0]
+			found = true
+		}
 	case "statefulset":
-		workloadList, err = storageCli.QueryK8SStatefulSet(clusterUID, namespaceName)
+		workload, err := storageCli.GetK8SStatefulSet(clusterUID, namespaceName, workloadName)
+		if err != nil {
+			blog.Warnf("query statefulset %s/%s from storage failed: %s, skip CR owner check",
+				namespaceName, workloadName, err.Error())
+			return false, ""
+		}
+		if workload == nil {
+			blog.Warnf("statefulset %s/%s not found in storage, skip CR owner check",
+				namespaceName, workloadName)
+			return false, ""
+		}
+		if len(workload.Data.OwnerReferences) > 0 {
+			ownerRef = workload.Data.OwnerReferences[0]
+			found = true
+		}
 	default:
 		return false, ""
-	}
-
-	if err != nil {
-		blog.Warnf("query %s %s from storage failed: %s, skip CR owner check",
-			workloadKind, workloadName, err.Error())
-		return false, ""
-	}
-
-	if workloadList == nil {
-		blog.Warnf("%s %s not found in storage, skip CR owner check",
-			workloadKind, workloadName)
-		return false, ""
-	}
-
-	// 查找匹配的 Workload 并获取其 Owner
-	var ownerRef metav1.OwnerReference
-	found := false
-
-	switch w := workloadList.(type) {
-	case []*storage.Deployment:
-		for _, deploy := range w {
-			if deploy.Data.Name == workloadName && len(deploy.Data.OwnerReferences) > 0 {
-				ownerRef = deploy.Data.OwnerReferences[0]
-				found = true
-				break
-			}
-		}
-	case []*storage.StatefulSet:
-		for _, ss := range w {
-			if ss.Data.Name == workloadName && len(ss.Data.OwnerReferences) > 0 {
-				ownerRef = ss.Data.OwnerReferences[0]
-				found = true
-				break
-			}
-		}
 	}
 
 	if !found {

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/option/option.go
@@ -13,7 +13,9 @@
 // Package option define options for synchronizer
 package option
 
-import "github.com/Tencent/bk-bcs/bcs-common/common/conf"
+import (
+	"github.com/Tencent/bk-bcs/bcs-common/common/conf"
+)
 
 // BkcmdbSynchronizerOption options for CostManager
 type BkcmdbSynchronizerOption struct {
@@ -29,12 +31,39 @@ type BkcmdbSynchronizerOption struct {
 
 // SynchronizerConfig synchronizer config
 type SynchronizerConfig struct {
-	Env       string `json:"env"`
-	Replicas  int    `json:"replicas"`
-	BkBizID   int64  `json:"bkBizID"`
-	HostID    int64  `json:"hostID"`
-	WhiteList string `json:"whiteList"`
-	BlackList string `json:"blackList"`
+	Env                    string   `json:"env"`
+	Replicas               int      `json:"replicas"`
+	BkBizID                int64    `json:"bkBizID"`
+	HostID                 int64    `json:"hostID"`
+	WhiteList              string   `json:"whiteList"`
+	BlackList              string   `json:"blackList"`
+	// CustomResourceTypes map from clusterID to custom resource kinds to sync
+	// Only clusters configured in this map will have custom resources synced
+	// Example: {"cluster-id-1": ["BkApp", "CronJob"], "cluster-id-2": ["BkApp"]}
+	CustomResourceTypes map[string][]string `json:"customResourceTypes"`
+}
+
+// CustomResourceType defines parsed custom resource type configuration.
+type CustomResourceType struct {
+	// ResourceType is the custom resource type name (e.g., "BkApp")
+	ResourceType string
+}
+
+// ParseCustomResourceTypes parses the custom resource types configuration.
+// Configuration format: map[clusterID][]string
+// Example: {"cluster-id-1": ["BkApp", "CronJob"], "cluster-id-2": ["BkApp"]}
+func ParseCustomResourceTypes(configs map[string][]string) map[string][]CustomResourceType {
+	result := make(map[string][]CustomResourceType, len(configs))
+	for clusterID, kinds := range configs {
+		crTypes := make([]CustomResourceType, 0, len(kinds))
+		for _, kind := range kinds {
+			crTypes = append(crTypes, CustomResourceType{
+				ResourceType: kind,
+			})
+		}
+		result[clusterID] = crTypes
+	}
+	return result
 }
 
 // ClientConfig client config

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/store/model/model-customresource.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/store/model/model-customresource.go
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"gorm.io/gorm"
+)
+
+// CustomResource defines the custom resource struct.
+type CustomResource struct {
+	WorkloadBase             `json:",inline" gorm:",inline"`
+	Labels                  MapStringString          `json:"labels,omitempty" gorm:"column:labels;type:json"`
+	Selector                LabelSelector            `json:"selector,omitempty" gorm:"column:selector;type:json"`
+	Replicas                int64                    `json:"replicas,omitempty" gorm:"column:replicas"`
+	MinReadySeconds         int64                    `json:"min_ready_seconds,omitempty" gorm:"column:min_ready_seconds"`
+	StrategyType            DeploymentStrategyType   `json:"strategy_type,omitempty" gorm:"column:strategy_type"`
+	RollingUpdateStrategy   RollingUpdateDeployment   `json:"rolling_update_strategy,omitempty" gorm:"column:rolling_update_strategy;type:json"` //nolint
+	// CRKind is the kind of custom resource (e.g., "CronJob", "Task", etc.)
+	CRKind string `json:"cr_kind,omitempty" gorm:"column:cr_kind;index"`
+	// CRApiVersion is the api version of custom resource (e.g., "batch.tkestack.io/v1")
+	CRApiVersion string `json:"cr_api_version,omitempty" gorm:"column:cr_api_version;index"`
+}
+
+// CustomResourceMigrate function uses GORM's AutoMigrate method to automatically migrate
+// the database table corresponding to the CustomResource struct.
+func CustomResourceMigrate(db *gorm.DB) error {
+	return db.AutoMigrate(&CustomResource{})
+}
+
+// TableName method specifies the database table name for CustomResource struct as "customresource".
+func (c CustomResource) TableName() string {
+	return "customresource"
+}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -2555,6 +2555,82 @@ func (s *Syncer) SyncStoreWorkload(bkCluster *bkcmdbkube.Cluster, db *gorm.DB) e
 	if err != nil {
 		blog.Errorf("syncStore PodsWordload err: %v", err)
 	}
+	err = s.SyncStoreCustomResource(bkCluster, db)
+	if err != nil {
+		blog.Errorf("syncStore CustomResource err: %v", err)
+	}
+	return nil
+}
+
+// SyncStoreCustomResource 同步 CustomResource 信息到数据库
+func (s *Syncer) SyncStoreCustomResource(bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// Check if this cluster is configured for custom resource sync
+	clusterID := bkCluster.Uid
+	crKinds, ok := s.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+	if !ok || len(crKinds) == 0 {
+		blog.Infof("cluster %s not configured for custom resource sync, skip", clusterID)
+		return nil
+	}
+
+	err := model.CustomResourceMigrate(db)
+	if err != nil {
+		blog.Errorf("migrate custom resource failed, err: %s", err.Error())
+		return fmt.Errorf("migrate custom resource failed, err: %s", err.Error())
+	}
+
+	// GetBkWorkloads get bkworkloads
+	bkCustomResources, err := s.GetBkWorkloads(bkCluster.BizID, "customResource", &client.PropertyFilter{
+		Condition: "AND",
+		Rules: []client.Rule{
+			{
+				Field:    "cluster_uid",
+				Operator: "in",
+				Value:    []string{bkCluster.Uid},
+			},
+		},
+	}, false, nil)
+	if err != nil {
+		blog.Errorf("get bk custom resource failed, err: %s", err.Error())
+		return fmt.Errorf("get bk custom resource failed, err: %s", err.Error())
+	}
+
+	customResourceMarshal, err := json.Marshal(bkCustomResources)
+	if err != nil {
+		blog.Errorf("marshal bk custom resource failed, err: %s", err.Error())
+	}
+	var customResources []model.CustomResource
+	err = json.Unmarshal(customResourceMarshal, &customResources)
+	if err != nil {
+		blog.Errorf("unmarshal bk custom resource failed, err: %s", err.Error())
+		return fmt.Errorf("unmarshal bk custom resource failed, err: %s", err.Error())
+	}
+
+	// Filter custom resources by configured crKinds
+	filteredCRs := make([]model.CustomResource, 0)
+	for _, cr := range customResources {
+		if exists, _ := common.InArray(cr.CRKind, crKinds); exists {
+			filteredCRs = append(filteredCRs, cr)
+		}
+	}
+
+	for _, customResource := range filteredCRs {
+		var existCustomResource model.CustomResource
+		if errCR := db.Where("id = ?", customResource.ID).First(&existCustomResource).Error; errCR != nil {
+			if errors.Is(errCR, gorm.ErrRecordNotFound) {
+				if errCC := db.Create(&customResource).Error; errCC != nil {
+					blog.Errorf("syncStore create custom resource err: %v", errCC)
+				}
+			} else {
+				blog.Errorf("syncStore get custom resource err: %v", errCR)
+			}
+		} else {
+			if errCS := db.Save(&customResource).Error; errCS != nil {
+				blog.Errorf("syncStore update custom resource err: %v", errCS)
+			} else {
+				blog.Infof("syncStore update custom resource success, customResource: %d", customResource.ID)
+			}
+		}
+	}
 	return nil
 }
 

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -5889,11 +5889,11 @@ func (s *Syncer) syncCustomResources(cluster *cmp.Cluster, bkCluster *bkcmdbkube
 				// Add new workload
 				if bkNs, ok := bkNamespaceMap[nsName]; ok {
 					toAddData := &client.CreateBcsWorkloadRequestData{
-						NamespaceID: &bkNs.ID,
-						Name:        &crName,
-						Labels:      &labels,
-						Replicas:    &replicas,
-						CRKind:      &crKind,
+						NamespaceID:  &bkNs.ID,
+						Name:         &crName,
+						Labels:       &labels,
+						Replicas:     &replicas,
+						CRKind:       &crKind,
 						CRApiVersion: &crApiVersion,
 					}
 					if _, ok = crToAdd[bkNs.BizID]; ok {

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -5939,6 +5939,36 @@ func (s *Syncer) syncCustomResources(cluster *cmp.Cluster, bkCluster *bkcmdbkube
 			}
 		}
 
+		// Delete pods associated with CRs before deleting CRs
+		// This is necessary because if a CR still has associated Pods in CMDB, the delete-workload-api will fail
+		for _, crID := range crToDelete {
+			bkPods, errGetPods := s.GetBkPods(bkCluster.BizID, &client.PropertyFilter{
+				Condition: "AND",
+				Rules: []client.Rule{
+					{
+						Field:    "ref.kind",
+						Operator: "in",
+						Value:    []string{"customResource"},
+					},
+					{
+						Field:    "ref.id",
+						Operator: "in",
+						Value:    []int64{crID},
+					},
+				},
+			}, true, db)
+			if errGetPods == nil && len(*bkPods) > 0 {
+				podIDs := make([]int64, 0)
+				for _, pod := range *bkPods {
+					podIDs = append(podIDs, pod.ID)
+				}
+				blog.Infof("customResource id=%d has %d pods, delete them first", crID, len(podIDs))
+				if errDelPods := s.DeleteBkPods(bkCluster, &podIDs, db); errDelPods != nil {
+					blog.Errorf("delete pods for customResource id=%d failed: %v", crID, errDelPods)
+				}
+			}
+		}
+
 		s.DeleteBkWorkloads(bkCluster, kind, &crToDelete, db) // nolint not checked
 		s.CreateBkWorkloads(bkCluster, kind, crToAdd, db)
 		s.UpdateBkWorkloads(bkCluster, kind, &crToUpdate, db)

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -469,6 +469,12 @@ func (s *Syncer) SyncWorkloads(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Clust
 		blog.Errorf("sync workload pods failed, err: %s", err.Error())
 	}
 
+	// syncCustomResources sync custom resources
+	err = s.syncCustomResources(cluster, bkCluster, db)
+	if err != nil {
+		blog.Errorf("sync custom resources failed, err: %s", err.Error())
+	}
+
 	return err
 }
 
@@ -5604,5 +5610,238 @@ func (s *Syncer) deleteAllByClusterNamespace(bkCluster *bkcmdbkube.Cluster) erro
 			}
 		}
 	}
+	return nil
+}
+
+// syncCustomResources sync custom resources
+// nolint funlen
+func (s *Syncer) syncCustomResources(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
+	// Check if this cluster is configured for custom resource sync
+	clusterID := cluster.ClusterID
+	crKinds, ok := s.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+	if !ok || len(crKinds) == 0 {
+		blog.Infof("cluster %s not configured for custom resource sync, skip", clusterID)
+		return nil
+	}
+
+	storageCli, err := s.GetBcsStorageClient()
+	if err != nil {
+		blog.Errorf("get bcs storage client failed, err: %s", err.Error())
+		return err
+	}
+
+	// Get bk namespaces
+	bkNamespaceList, err := s.GetBkNamespaces(bkCluster.BizID, &client.PropertyFilter{
+		Condition: "AND",
+		Rules: []client.Rule{
+			{
+				Field:    "cluster_uid",
+				Operator: "in",
+				Value:    []string{bkCluster.Uid},
+			},
+		},
+	}, true, db)
+	if err != nil {
+		blog.Errorf("get bk namespace failed, err: %s", err.Error())
+		return err
+	}
+
+	bkNamespaceMap := make(map[string]*bkcmdbkube.Namespace)
+	for k, v := range *bkNamespaceList {
+		bkNamespaceMap[v.Name] = &(*bkNamespaceList)[k]
+	}
+
+	kind := "customResource"
+
+	// Iterate through each CR kind configured for this cluster
+	for _, crKind := range crKinds {
+		blog.Infof("syncing custom resource kind %s for cluster %s", crKind, clusterID)
+
+		// Query all CRs of this kind from bcs-storage
+		crList := make([]map[string]interface{}, 0)
+		for _, ns := range *bkNamespaceList {
+			var nsCRList []map[string]interface{}
+			filter := map[string]string{
+				"clusterId": clusterID,
+			}
+			err := storageCli.ListCustomResource(crKind, filter, &nsCRList)
+			if err != nil {
+				blog.Errorf("query custom resource %s failed, err: %s", crKind, err.Error())
+				continue
+			}
+			// Filter by namespace since ListCustomResource doesn't filter by namespace
+			for _, cr := range nsCRList {
+				if crNamespace, ok := cr["namespace"].(string); ok && crNamespace == ns.Name {
+					crList = append(crList, cr)
+				}
+			}
+		}
+		blog.Infof("query custom resource %s success, got %d items", crKind, len(crList))
+
+		// Get existing bk workloads with kind=customResource and crKind filter
+		bkWorkloads, err := s.GetBkWorkloads(bkCluster.BizID, kind, &client.PropertyFilter{
+			Condition: "AND",
+			Rules: []client.Rule{
+				{
+					Field:    "cluster_uid",
+					Operator: "in",
+					Value:    []string{bkCluster.Uid},
+				},
+				{
+					Field:    "cr_kind",
+					Operator: "in",
+					Value:    []string{crKind},
+				},
+			},
+		}, true, db)
+		if err != nil {
+			blog.Errorf("get bk custom resources %s failed, err: %s", crKind, err.Error())
+			continue
+		}
+
+		// Convert bkWorkloads to a usable map
+		bkCRMap := make(map[string]map[string]interface{})
+		for _, bw := range *bkWorkloads {
+			if bwMap, ok := bw.(map[string]interface{}); ok {
+				key := ""
+				if ns, _ := bwMap["namespace"].(string); ns != "" {
+					key = ns
+				}
+				if name, _ := bwMap["name"].(string); name != "" {
+					key += "/" + name
+				}
+				if key != "" {
+					bkCRMap[key] = bwMap
+				}
+			}
+		}
+
+		crToAdd := make(map[int64][]client.CreateBcsWorkloadRequestData, 0)
+		crToUpdate := make(map[int64]*client.UpdateBcsWorkloadRequestData, 0)
+		crToDelete := make([]int64, 0)
+
+		// Build CR map from storage data
+		crMap := make(map[string]map[string]interface{})
+		for _, cr := range crList {
+			key := ""
+			if ns, _ := cr["namespace"].(string); ns != "" {
+				key = ns
+			}
+			if name, _ := cr["resourceName"].(string); name != "" {
+				key += "/" + name
+			}
+			if key != "" {
+				crMap[key] = cr
+			}
+		}
+
+		// Diff: find workloads to delete (exist in CMDB but not in storage)
+		for key, bkCR := range bkCRMap {
+			if _, ok := crMap[key]; !ok {
+				if id, ok := bkCR["id"].(float64); ok {
+					crToDelete = append(crToDelete, int64(id))
+					blog.Infof("customResource %s ToDelete: %s", crKind, key)
+				}
+			}
+		}
+
+		// Diff: find workloads to add/update
+		for key, cr := range crMap {
+			bkCR, exists := bkCRMap[key]
+
+			// Extract labels
+			var labels map[string]string
+			if crLabels, ok := cr["labels"].(map[string]interface{}); ok {
+				labels = make(map[string]string)
+				for k, v := range crLabels {
+					if vs, ok := v.(string); ok {
+						labels[k] = vs
+					}
+				}
+			}
+
+			// Extract replicas
+			var replicas int64
+			if crSpec, ok := cr["spec"].(map[string]interface{}); ok {
+				if r, ok := crSpec["replicas"].(float64); ok {
+					replicas = int64(r)
+				}
+			}
+
+			nsName := ""
+			if ns, _ := cr["namespace"].(string); ns != "" {
+				nsName = ns
+			}
+			crName := ""
+			if name, _ := cr["resourceName"].(string); name != "" {
+				crName = name
+			}
+			// Extract apiVersion from cr data
+			crApiVersion := ""
+			if crData, ok := cr["data"].(map[string]interface{}); ok {
+				if apiVersion, ok := crData["apiVersion"].(string); ok {
+					crApiVersion = apiVersion
+				}
+			}
+
+			if !exists {
+				// Add new workload
+				if bkNs, ok := bkNamespaceMap[nsName]; ok {
+					toAddData := &client.CreateBcsWorkloadRequestData{
+						NamespaceID: &bkNs.ID,
+						Name:        &crName,
+						Labels:      &labels,
+						Replicas:    &replicas,
+						CRKind:      &crKind,
+						CRApiVersion: &crApiVersion,
+					}
+					if _, ok = crToAdd[bkNs.BizID]; ok {
+						crToAdd[bkNs.BizID] = append(crToAdd[bkNs.BizID], *toAddData)
+					} else {
+						crToAdd[bkNs.BizID] = []client.CreateBcsWorkloadRequestData{*toAddData}
+					}
+					blog.Infof("customResource %s ToAdd: %s", crKind, key)
+				}
+			} else {
+				// Compare and update if needed
+				needUpdate := false
+				updateData := &client.UpdateBcsWorkloadRequestData{}
+
+				// Compare labels
+				if labels != nil {
+					if bkLabels, ok := bkCR["labels"].(map[string]interface{}); ok {
+						for k, v := range labels {
+							if bkV, ok := bkLabels[k].(string); !ok || bkV != v {
+								needUpdate = true
+								break
+							}
+						}
+					} else {
+						needUpdate = true
+					}
+				}
+
+				// Compare replicas
+				if !needUpdate {
+					if bkReplicas, ok := bkCR["replicas"].(float64); ok && int64(bkReplicas) != replicas {
+						updateData.Replicas = &replicas
+						needUpdate = true
+					}
+				}
+
+				if needUpdate {
+					if id, ok := bkCR["id"].(float64); ok {
+						crToUpdate[int64(id)] = updateData
+						blog.Infof("customResource %s ToUpdate: %s", crKind, key)
+					}
+				}
+			}
+		}
+
+		s.DeleteBkWorkloads(bkCluster, kind, &crToDelete, db) // nolint not checked
+		s.CreateBkWorkloads(bkCluster, kind, crToAdd, db)
+		s.UpdateBkWorkloads(bkCluster, kind, &crToUpdate, db)
+	}
+
 	return nil
 }

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -5111,8 +5111,39 @@ func (s *Syncer) UpdateBkWorkloads(
 }
 
 // DeleteBkWorkloads delete bkworkloads
+// Before deleting the workload, it will delete associated pods first
+// because CMDB's delete-workload-api will fail if the workload still has associated pods
 func (s *Syncer) DeleteBkWorkloads(bkCluster *bkcmdbkube.Cluster, kind string, toDelete *[]int64, db *gorm.DB) error {
 	if len(*toDelete) > 0 {
+		// Delete associated pods before deleting workload
+		for _, id := range *toDelete {
+			bkPods, errGetPods := s.GetBkPods(bkCluster.BizID, &client.PropertyFilter{
+				Condition: "AND",
+				Rules: []client.Rule{
+					{
+						Field:    "ref.kind",
+						Operator: "in",
+						Value:    []string{kind},
+					},
+					{
+						Field:    "ref.id",
+						Operator: "in",
+						Value:    []int64{id},
+					},
+				},
+			}, true, db)
+			if errGetPods == nil && len(*bkPods) > 0 {
+				podIDs := make([]int64, 0)
+				for _, pod := range *bkPods {
+					podIDs = append(podIDs, pod.ID)
+				}
+				blog.Infof("workload %s id=%d has %d pods, delete them first", kind, id, len(podIDs))
+				if errDelPods := s.DeleteBkPods(bkCluster, &podIDs, db); errDelPods != nil {
+					blog.Errorf("delete pods for workload %s id=%d failed: %v", kind, id, errDelPods)
+				}
+			}
+		}
+
 		// DeleteBcsWorkload deletes the BCS workload with the given request.
 		err := s.CMDBClient.DeleteBcsWorkload(&client.DeleteBcsWorkloadRequest{
 			BKBizID: &bkCluster.BizID,
@@ -5935,36 +5966,6 @@ func (s *Syncer) syncCustomResources(cluster *cmp.Cluster, bkCluster *bkcmdbkube
 						crToUpdate[int64(id)] = updateData
 						blog.Infof("customResource %s ToUpdate: %s", crKind, key)
 					}
-				}
-			}
-		}
-
-		// Delete pods associated with CRs before deleting CRs
-		// This is necessary because if a CR still has associated Pods in CMDB, the delete-workload-api will fail
-		for _, crID := range crToDelete {
-			bkPods, errGetPods := s.GetBkPods(bkCluster.BizID, &client.PropertyFilter{
-				Condition: "AND",
-				Rules: []client.Rule{
-					{
-						Field:    "ref.kind",
-						Operator: "in",
-						Value:    []string{"customResource"},
-					},
-					{
-						Field:    "ref.id",
-						Operator: "in",
-						Value:    []int64{crID},
-					},
-				},
-			}, true, db)
-			if errGetPods == nil && len(*bkPods) > 0 {
-				podIDs := make([]int64, 0)
-				for _, pod := range *bkPods {
-					podIDs = append(podIDs, pod.ID)
-				}
-				blog.Infof("customResource id=%d has %d pods, delete them first", crID, len(podIDs))
-				if errDelPods := s.DeleteBkPods(bkCluster, &podIDs, db); errDelPods != nil {
-					blog.Errorf("delete pods for customResource id=%d failed: %v", crID, errDelPods)
 				}
 			}
 		}

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -38,6 +38,7 @@ import (
 	"gorm.io/gorm"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/client"
@@ -488,6 +489,10 @@ func (s *Syncer) syncDeployments(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Clu
 		blog.Errorf("get bcs storage client failed, err: %s", err.Error())
 	}
 
+	// 获取该集群的 CR 白名单
+	clusterID := cluster.ClusterID
+	crKinds := s.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
+
 	// GetBkNamespaces get bknamespaces
 	bkNamespaceList, err := s.GetBkNamespaces(bkCluster.BizID, &client.PropertyFilter{
 		Condition: "AND",
@@ -571,6 +576,16 @@ func (s *Syncer) syncDeployments(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Clu
 	}
 
 	for k, v := range deploymentMap {
+		// 检查该 Deployment 是否被 CR 拥有
+		if len(crKinds) > 0 {
+			ownedByCR, crKind := s.isWorkloadOwnedByCR(cluster.ClusterID, v.Data.Namespace, "deployment", v.Data.Name, storageCli, crKinds)
+			if ownedByCR {
+				blog.Infof("deployment %s/%s is owned by CR %s, skip full sync",
+					v.Data.Namespace, v.Data.Name, crKind)
+				continue
+			}
+		}
+
 		if _, ok := bkDeploymentMap[k]; !ok {
 			// GenerateBkDeployment generate bkdeployment from k8sdeployment
 			toAddData := s.GenerateBkDeployment(bkNamespaceMap[v.Data.Namespace], v)
@@ -602,6 +617,78 @@ func (s *Syncer) syncDeployments(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Clu
 	return nil
 }
 
+// isWorkloadOwnedByCR 检查 workload 的 owner 是否在 CR 白名单中
+// 如果是，返回 (true, crKind)；否则返回 (false, "")
+func (s *Syncer) isWorkloadOwnedByCR(
+	clusterID, namespaceName, workloadKind, workloadName string,
+	storageCli bcsapi.Storage, crKinds []string) (bool, string) {
+
+	if len(crKinds) == 0 {
+		return false, ""
+	}
+
+	// 查询 Workload 详细信息
+	var workloadList interface{}
+	var err error
+
+	switch workloadKind {
+	case "deployment":
+		workloadList, err = storageCli.QueryK8SDeployment(clusterID, namespaceName)
+	case "statefulset":
+		workloadList, err = storageCli.QueryK8SStatefulSet(clusterID, namespaceName)
+	default:
+		return false, ""
+	}
+
+	if err != nil {
+		blog.Warnf("query %s %s from storage failed: %s, skip CR owner check",
+			workloadKind, workloadName, err.Error())
+		return false, ""
+	}
+
+	if workloadList == nil {
+		blog.Warnf("%s %s not found in storage, skip CR owner check",
+			workloadKind, workloadName)
+		return false, ""
+	}
+
+	// 查找匹配的 Workload 并获取其 Owner
+	var ownerRef metav1.OwnerReference
+	found := false
+
+	switch w := workloadList.(type) {
+	case []*storage.Deployment:
+		for _, deploy := range w {
+			if deploy.Data.Name == workloadName && len(deploy.Data.OwnerReferences) > 0 {
+				ownerRef = deploy.Data.OwnerReferences[0]
+				found = true
+				break
+			}
+		}
+	case []*storage.StatefulSet:
+		for _, ss := range w {
+			if ss.Data.Name == workloadName && len(ss.Data.OwnerReferences) > 0 {
+				ownerRef = ss.Data.OwnerReferences[0]
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		return false, ""
+	}
+
+	// 检查 owner 是否在 CR 白名单中
+	if common.IsKindInSlice(ownerRef.Kind, crKinds) {
+		blog.Infof("workload %s %s/%s is owned by CR %s, skip sync",
+			workloadKind, namespaceName, workloadName, ownerRef.Kind)
+		return true, ownerRef.Kind
+	}
+
+	return false, ""
+}
+
 // syncStatefulSets sync statefulsets
 // nolint funlen
 func (s *Syncer) syncStatefulSets(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Cluster, db *gorm.DB) error {
@@ -611,6 +698,10 @@ func (s *Syncer) syncStatefulSets(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Cl
 	if err != nil {
 		blog.Errorf("get bcs storage client failed, err: %s", err.Error())
 	}
+
+	// 获取该集群的 CR 白名单
+	clusterID := cluster.ClusterID
+	crKinds := s.BkcmdbSynchronizerOption.Synchronizer.CustomResourceTypes[clusterID]
 
 	// GetBkNamespaces get bknamespaces
 	bkNamespaceList, err := s.GetBkNamespaces(bkCluster.BizID, &client.PropertyFilter{
@@ -694,6 +785,16 @@ func (s *Syncer) syncStatefulSets(cluster *cmp.Cluster, bkCluster *bkcmdbkube.Cl
 	}
 
 	for k, v := range statefulSetMap {
+		// 检查该 StatefulSet 是否被 CR 拥有
+		if len(crKinds) > 0 {
+			ownedByCR, crKind := s.isWorkloadOwnedByCR(cluster.ClusterID, v.Data.Namespace, "statefulset", v.Data.Name, storageCli, crKinds)
+			if ownedByCR {
+				blog.Infof("statefulset %s/%s is owned by CR %s, skip full sync",
+					v.Data.Namespace, v.Data.Name, crKind)
+				continue
+			}
+		}
+
 		if _, ok := bkStatefulSetMap[k]; !ok {
 			toAddData := s.GenerateBkStatefulSet(bkNamespaceMap[v.Data.Namespace], v)
 

--- a/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
+++ b/bcs-services/bcs-bkcmdb-synchronizer/internal/pkg/syncer/syncer.go
@@ -2089,6 +2089,7 @@ func (s *Syncer) SyncStoreMigrate(db *gorm.DB) {
 	_ = model.GameDeploymentMigrate(db)
 	_ = model.GameStatefulSetMigrate(db)
 	_ = model.PodsWorkloadMigrate(db)
+	_ = model.CustomResourceMigrate(db)
 	_ = model.PodMigrate(db)
 	_ = model.ContainerMigrate(db)
 }

--- a/install/conf/bcs-services/bcs-bkcmdb-synchronizer/bcs-bkcmdb-synchronizer.json.template
+++ b/install/conf/bcs-services/bcs-bkcmdb-synchronizer/bcs-bkcmdb-synchronizer.json.template
@@ -5,7 +5,8 @@
     "bkBizID": ${synchronizer_bkBizID},
     "hostID": ${synchronizer_hostID},
     "whiteList": "${synchronizer_whiteList}",
-    "blackList": "${synchronizer_blackList}"
+    "blackList": "${synchronizer_blackList}",
+    "customResourceTypes": {}
   },
   "client": {
     "client_crt_pwd": "${client_clientCrtPwd}",


### PR DESCRIPTION
1. 更新版本bcs-common依赖
2. cmdb-client 支持 customResource的workload
3. 全量同步&增量同步支持同步CRD，用白名单机制（集群+CR维度）
4. CR直接关联Pod，忽略中间可能会有的 ReplicaSet、Deployment或Statefulset等
5. 增加删除workload前删除其关联的pod逻辑，修复 workload 删除事件先于 pod 被处理，没有删除pod导致workload删除失败的问题