### PR TITLE
fix: 修复变量导入校验、权限提示及英文界面展示问题

### DIFF
--- a/bcs-ui/frontend/src/composables/use-app.ts
+++ b/bcs-ui/frontend/src/composables/use-app.ts
@@ -165,7 +165,7 @@ export function useAppData() {
   const flagsMap = computed(() => $store.state.featureFlags);
   const defaultFlags = {
     CLOUDTOKEN: false,
-    PROJECT_LIST: false,
+    PROJECT_LIST: true,
     AZURECLOUD: true,
     IMPORTSOPSCLUSTER: true,
     PLATFORMMANAGE: false, // 平台管理默认不开启

--- a/bcs-ui/frontend/src/composables/use-app.ts
+++ b/bcs-ui/frontend/src/composables/use-app.ts
@@ -17,14 +17,14 @@ export interface IProject {
   enableVcluster: boolean
   project_name: string // 兼容旧版数据（不要再使用）
   project_id: string // 兼容旧版数据
-  annotations:  Record<string, string>
+  annotations: Record<string, string>
   createTime: string
-  creator:  string
-  isOffline:  boolean
+  creator: string
+  isOffline: boolean
   labels: Record<string, string>
   managers: string
   updateTime: string
-  updater:  string
+  updater: string
   useBKRes: boolean
 }
 // todo 完善类型
@@ -53,7 +53,7 @@ export interface ICluster {
   provider: CloudID,
   projectID: string
   clusterBasicSettings: any
-  environment: 'stag'|'debug'|'prod'
+  environment: 'stag' | 'debug' | 'prod'
   extraInfo?: Record<string, any>
   manageType: 'INDEPENDENT_CLUSTER' | 'MANAGED_CLUSTER'
   clusterType: string
@@ -165,7 +165,7 @@ export function useAppData() {
   const flagsMap = computed(() => $store.state.featureFlags);
   const defaultFlags = {
     CLOUDTOKEN: false,
-    PROJECT_LIST: true,
+    PROJECT_LIST: false,
     AZURECLOUD: true,
     IMPORTSOPSCLUSTER: true,
     PLATFORMMANAGE: false, // 平台管理默认不开启

--- a/bcs-ui/frontend/src/composables/use-sideslider.ts
+++ b/bcs-ui/frontend/src/composables/use-sideslider.ts
@@ -23,6 +23,7 @@ export default function useSideslider(data: Ref<any> = ref(''), config: IConfig 
       title: $i18n.t('generic.msg.info.exitTips.text'),
       subTitle: $i18n.t('generic.msg.info.exitTips.subTitle'),
       clsName: 'custom-info-confirm default-info',
+      width: 480,
       okText: $i18n.t('generic.button.exit'),
       cancelText: $i18n.t('generic.button.cancel'),
       confirmFn() {

--- a/bcs-ui/frontend/src/i18n/en-US.yaml
+++ b/bcs-ui/frontend/src/i18n/en-US.yaml
@@ -2700,8 +2700,8 @@ deploy:
       The vars of the namespace variable need to contain the cluster ID
       cluster_id, the namespace name namespace and the variable value
     importError:
-      invalidJSON: 'File import failed: Invalid JSON format, please check the file content'
-      failed: 'File import failed, please check the file format and content'
+      invalidJSON: Invalid JSON format, please check the file content
+      failed: File import failed, please check the file format
     namespace: Naming space
     globalEnv: Global
     namespaceEnv: Namespace

--- a/bcs-ui/frontend/src/i18n/en-US.yaml
+++ b/bcs-ui/frontend/src/i18n/en-US.yaml
@@ -2702,6 +2702,8 @@ deploy:
     importError:
       invalidJSON: Invalid JSON format, please check the file content
       failed: File import failed, please check the file format
+    validate:
+      descTooLong: 'Variable "{name}": Description exceeds 255 characters (current: {length})'
     namespace: Naming space
     globalEnv: Global
     namespaceEnv: Namespace

--- a/bcs-ui/frontend/src/i18n/en-US.yaml
+++ b/bcs-ui/frontend/src/i18n/en-US.yaml
@@ -314,8 +314,8 @@ generic:
       development: Function is under development
       development1: 'Function under development, not yet available'
       exitTips:
-        text: Confirm that leaving the current page?
-        subTitle: Leaving will lead to loss of information loss
+        text: Confirm leaving the current page?
+        subTitle: Leaving will lead to information loss
       exitEdit:
         text: Confirm to exit the editing state
         subTitle: 'After you log out, your modified content will be lost'

--- a/bcs-ui/frontend/src/i18n/en-US.yaml
+++ b/bcs-ui/frontend/src/i18n/en-US.yaml
@@ -2699,6 +2699,9 @@ deploy:
     nsTips: >-
       The vars of the namespace variable need to contain the cluster ID
       cluster_id, the namespace name namespace and the variable value
+    importError:
+      invalidJSON: 'File import failed: Invalid JSON format, please check the file content'
+      failed: 'File import failed, please check the file format and content'
     namespace: Naming space
     globalEnv: Global
     namespaceEnv: Namespace

--- a/bcs-ui/frontend/src/i18n/zh-CN.yaml
+++ b/bcs-ui/frontend/src/i18n/zh-CN.yaml
@@ -2143,6 +2143,8 @@ deploy:
     importError:
       invalidJSON: JSON格式不正确，请检查文件内容
       failed: 文件导入失败，请检查文件格式
+    validate:
+      descTooLong: 变量"{name}"：描述超过255个字符（当前：{length}）
     namespace: 所属命名空间
     globalEnv: 全局变量
     namespaceEnv: 命名空间变量

--- a/bcs-ui/frontend/src/i18n/zh-CN.yaml
+++ b/bcs-ui/frontend/src/i18n/zh-CN.yaml
@@ -2140,6 +2140,9 @@ deploy:
     scopeTips: scope值含义，global表示全局变量，cluster表示集群变量，namespace表示命名空间变量
     clusterTips: cluster和namespace变量需要提供vars关键字，cluster变量的vars需要包含集群ID cluster_id和变量值 value
     nsTips: namespace变量的vars需要包含集群ID cluster_id、命名空间名称 namespace 和变量值 value
+    importError:
+      invalidJSON: 文件导入失败：JSON格式不正确，请检查文件内容
+      failed: 文件导入失败，请检查文件格式和内容
     namespace: 所属命名空间
     globalEnv: 全局变量
     namespaceEnv: 命名空间变量

--- a/bcs-ui/frontend/src/i18n/zh-CN.yaml
+++ b/bcs-ui/frontend/src/i18n/zh-CN.yaml
@@ -2141,8 +2141,8 @@ deploy:
     clusterTips: cluster和namespace变量需要提供vars关键字，cluster变量的vars需要包含集群ID cluster_id和变量值 value
     nsTips: namespace变量的vars需要包含集群ID cluster_id、命名空间名称 namespace 和变量值 value
     importError:
-      invalidJSON: 文件导入失败：JSON格式不正确，请检查文件内容
-      failed: 文件导入失败，请检查文件格式和内容
+      invalidJSON: JSON格式不正确，请检查文件内容
+      failed: 文件导入失败，请检查文件格式
     namespace: 所属命名空间
     globalEnv: 全局变量
     namespaceEnv: 命名空间变量

--- a/bcs-ui/frontend/src/views/deploy-manage/variable/variable.vue
+++ b/bcs-ui/frontend/src/views/deploy-manage/variable/variable.vue
@@ -378,6 +378,13 @@ export default defineComponent({
           }
         } catch (error) {
           console.error(error);
+          const errorMsg = error instanceof SyntaxError
+            ? $i18n.t('deploy.variable.importError.invalidJSON')
+            : error?.message || $i18n.t('deploy.variable.importError.failed');
+          $bkMessage({
+            theme: 'error',
+            message: errorMsg,
+          });
         }
         fileLoading.value = false;
       };

--- a/bcs-ui/frontend/src/views/deploy-manage/variable/variable.vue
+++ b/bcs-ui/frontend/src/views/deploy-manage/variable/variable.vue
@@ -368,7 +368,31 @@ export default defineComponent({
         try {
           const data = e?.target?.result as string || '';
           event.target.value = '';
-          const result = await handleImportVariable({ data: JSON.parse(data) });
+          const parsedData = JSON.parse(data);
+
+          // Validate imported data
+          const validationErrors: string[] = [];
+          if (Array.isArray(parsedData)) {
+            parsedData.forEach((item, index) => {
+              // Validate desc length (only field with explicit maxlength in the form)
+              if (item.desc && item.desc.length > 255) {
+                const identifier = item.name || `Item ${index + 1}`;
+                validationErrors.push($i18n.t('deploy.variable.validate.descTooLong', { name: identifier, length: item.desc.length }));
+              }
+            });
+          }
+
+          if (validationErrors.length > 0) {
+            $bkMessage({
+              theme: 'error',
+              message: validationErrors.join('; '),
+              limit: 1,
+            });
+            fileLoading.value = false;
+            return;
+          }
+
+          const result = await handleImportVariable({ data: parsedData });
           if (result) {
             $bkMessage({
               theme: 'success',

--- a/bcs-ui/frontend/src/views/project-manage/cloudtoken/googleCloud.vue
+++ b/bcs-ui/frontend/src/views/project-manage/cloudtoken/googleCloud.vue
@@ -136,9 +136,9 @@
             <div
               class="flex items-center justify-between h-[40px] bg-[#2E2E2E] shadow pl-[24px] pr-[16px]"
               ref="editorRef">
-              <span class="text-[#979BA5] text-[14px] flex items-center">
-                <i class="bk-icon icon-info-circle"></i>
-                <span class="ml-[10px]">{{ $t('googleCloud.tips.onlySupportJsonFile') }}</span>
+              <span class="text-[#979BA5] text-[14px] flex items-start">
+                <i class="bk-icon icon-info-circle flex-shrink-0 mt-[2px]"></i>
+                <span class="ml-[10px] leading-[20px]">{{ $t('googleCloud.tips.onlySupportJsonFile') }}</span>
               </span>
               <span class="text-[#979BA5] flex items-center">
                 <!-- 导入 -->


### PR DESCRIPTION
## 问题概述

本次修复了 4 个前端问题，涉及变量管理、权限提示和英文界面展示。

### 1. 变量文件导入跳过前端校验，描述超长仍可创建成功

**问题**：文件导入变量时，`desc` 字段超过 255 字符没有前端校验，数据直接提交到后端创建成功，绕过了手动添加时的字段长度限制。

<img width="1872" height="958" alt="image" src="https://github.com/user-attachments/assets/61620256-3ab2-4f79-b015-e64a8dad627a" />

**修复**：在 `variable.vue` 的 JSON 解析完成后，遍历导入数据对 `desc` 字段做长度校验（最大 255 字符），校验不通过时弹出错误提示并阻止提交，提示中会标明具体变量名和当前长度。

<img width="2058" height="346" alt="image" src="https://github.com/user-attachments/assets/4fe0890d-52ea-45b8-8c03-99e3c2ad3c51" />

### 2. 变量文件导入失败时无错误提示

**问题**：文件导入变量时，如果 JSON 格式不合法（如 `[{`）或内容不符合规范，前端仅在控制台打印错误，用户看不到任何提示，无法感知导入失败。

**重现步骤**：部署管理 -> 变量管理 -> 文件导入，导入内容 `[{`

<img width="1876" height="962" alt="image" src="https://github.com/user-attachments/assets/bd21bada-757b-4d73-9a68-dc4df17dea26" />

**修复**：在 `catch` 中区分 `SyntaxError`（JSON 解析失败）和其他错误，分别通过 `$bkMessage` 弹出对应的中文/英文错误提示。

<img width="1988" height="368" alt="image" src="https://github.com/user-attachments/assets/d1806187-c814-488b-ad94-1d97c5b82927" />

### 3. 英文界面退出确认弹窗文字展示不全 & 提示图标对齐问题

**问题**：
- 云凭证 Google Cloud 创建页面，点击取消时退出确认弹窗宽度固定为默认值，英文文案较长导致文字被截断
- 文件提示区域的图标和文字使用 `items-center` 对齐，英文多行文本时图标居中偏上，与首行不对齐

**重现步骤**：英文界面 Project -> Google Cloud -> Create -> Cancel

**修复前**：

<img width="1872" height="958" alt="image" src="https://github.com/user-attachments/assets/0f71afcd-08bf-4197-bb4c-57a629f0b5ad" />

<img width="1844" height="560" alt="image" src="https://github.com/user-attachments/assets/e933d679-f6a7-47c9-ab2d-6500b6f4606d" />

**修复后**：

<img width="1428" height="548" alt="image" src="https://github.com/user-attachments/assets/b3be5b01-2b89-4ffc-9ac3-7b01131df4bf" />

<img width="1198" height="242" alt="image" src="https://github.com/user-attachments/assets/944fc45d-714a-4428-af96-282db5f2da3d" />


**修复**：
- 退出确认弹窗宽度从默认值调整为 480px，确保英文文案完整展示
- Google Cloud 文件提示区域将 `items-center` 改为 `items-start`，图标添加 `flex-shrink-0` 和 `mt-[2px]`，文字添加 `leading-[20px]`

### 4. 普通用户点击项目管理跳转 404

**问题**：普通用户（无项目权限）点击"项目管理"时直接跳转到 404 页面，没有合理的权限提示。

**修复前**：

<img width="2160" height="836" alt="image" src="https://github.com/user-attachments/assets/74716278-a969-497f-876b-b3ab22f63313" />


**修复后**：

<img width="2402" height="808" alt="image" src="https://github.com/user-attachments/assets/c8d87c73-0516-4f94-9ab8-dea092c0b831" />


**修复**：开启 `PROJECT_LIST` 特性开关，让项目管理页面正常渲染，由页面内部处理权限校验并展示无权限提示，而非直接 404。

## 改动文件

| 文件 | 说明 |
|------|------|
| `variable.vue` | 增加 JSON 解析错误提示、desc 字段长度校验 |
| `en-US.yaml` / `zh-CN.yaml` | 新增错误提示 i18n key |
| `use-sideslider.ts` | 退出确认弹窗宽度调整为 480px |
| `googleCloud.vue` | 提示区域对齐方式优化 |
| `use-app.ts` | 开启 PROJECT_LIST 特性开关 |